### PR TITLE
bug/EIA-174 Fix issue with upload limits on document upload

### DIFF
--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -6,12 +6,14 @@ const deleteFileFromStorage = require('../helpers/deleteFileFromStorage');
 const {
     virusScanFile,
     checkTypeSizeAndDuplication,
+    displayErrorAndRemoveLargeFiles,
     connectToClamAV,
 } = require('../helpers/uploadedFileErrorChecks');
 
 const MAX_FILES = 50;
 const FORM_INPUT_NAME = 'documents';
 const MULTER_FILE_COUNT_ERR_CODE = 'LIMIT_FILE_COUNT';
+
 const inDevEnvironment = process.env.NODE_ENV === 'development';
 
 const FileUploadController = {
@@ -62,16 +64,15 @@ const FileUploadController = {
     },
 
     _checkFilesForErrors(req, res, err) {
+        displayErrorAndRemoveLargeFiles(req);
         if (err) {
             const fileLimitExceeded = err.code === MULTER_FILE_COUNT_ERR_CODE;
-
             if (fileLimitExceeded) {
                 req.session.eApp.uploadMessages.fileCountError = true;
-                sails.log.error(err.message, err.stack);
             } else {
-                sails.log.error(err);
                 res.serverError(err);
             }
+            sails.log.error(err);
         } else {
             virusScanFile(req, res);
             !inDevEnvironment &&
@@ -101,7 +102,7 @@ const FileUploadController = {
             return res.badRequest();
         }
         if (uploadedFileData.length === 0) {
-            sails.log.info("Item to delete wasn't found");
+            sails.log.error("Item to delete wasn't found");
             return res.notFound();
         }
         const updatedSession = FileUploadController._removeFileFromSessionArray(

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -258,6 +258,7 @@ function displayErrorAndRemoveLargeFiles(req) {
         }
     }
 }
+
 function formatFileSizeMb(bytes, decimalPlaces = 1) {
     return `${(bytes / 1_000_000).toFixed(decimalPlaces)}Mb`;
 }

--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -11,12 +11,10 @@ const sandbox = sinon.sandbox.create();
 
 // Tests are timing out
 describe.skip('FileUploadController', function () {
-    let sandbox;
     let userId = 100;
     let agent;
 
     beforeEach(function (done) {
-        sandbox = sandbox.sandbox.create();
         agent = request.agent(sails.hooks.http.app);
         // in the actual controller this helper returns user data from the session
         sandbox.stub(HelperService, 'getUserData').callsFake(() => ({
@@ -29,7 +27,6 @@ describe.skip('FileUploadController', function () {
 
     afterEach(function () {
         sandbox.restore();
-        done();
     });
 
     it('should return a redirect to the /upload-files page', function (done) {
@@ -221,6 +218,7 @@ describe('uploadFileHandler', () => {
                     },
                 },
             },
+            files: [],
             _sails: {
                 config: {
                     eAppS3Vals: {

--- a/tests/specs/helpers/uploadedFileErrorChecks.test.js
+++ b/tests/specs/helpers/uploadedFileErrorChecks.test.js
@@ -1,74 +1,125 @@
-const { expect } = require("chai");
-const sinon = require("sinon");
+const { expect } = require('chai');
+const sinon = require('sinon');
+const fs = require('fs');
 const {
-  checkTypeSizeAndDuplication,
-} = require("../../../api/helpers/uploadedFileErrorChecks");
+    checkTypeSizeAndDuplication,
+    displayErrorAndRemoveLargeFiles,
+} = require('../../../api/helpers/uploadedFileErrorChecks');
 
+const sandbox = sinon.sandbox.create();
 
-describe("checkTypeSizeAndDuplication", () => {
-  const sessionStub = (uploadedFiles) => ({
-    eApp: {
-      uploadedFileData: uploadedFiles,
-      uploadMessages: {
-        errors: [],
-      },
-    },
-  });
-  const requestStub = (uploadedFiles = []) => ({
-      session: sessionStub(uploadedFiles),
-      headers: {
-          'content-length': 136542,
-      },
-  });
+describe('checkTypeSizeAndDuplication', () => {
+    afterEach(() => {
+        sandbox.restore();
+    });
 
-  const callbackSpy = sinon.spy();
+    const sessionStub = (uploadedFiles) => ({
+        eApp: {
+            uploadedFileData: uploadedFiles,
+            uploadMessages: {
+                errors: [],
+            },
+        },
+    });
+    const requestStub = (uploadedFiles = []) => ({
+        session: sessionStub(uploadedFiles),
+        headers: {
+            'content-length': 136542,
+        },
+    });
 
-  it("uploads file if it has no issues", () => {
-    const newUploadedFile = {
-      originalname: "file1.pdf",
-      mimetype: "application/pdf",
-    };
-    checkTypeSizeAndDuplication(requestStub(), newUploadedFile, callbackSpy);
-    expect(callbackSpy.calledWith(null, true)).to.be.true;
-  });
+    const callbackSpy = sinon.spy();
 
-  it("does not upload the file if it is too large", () => {
-    const newUploadedFile = {
-      originalname: "file2.pdf",
-      mimetype: "application/pdf",
-    };
-    const reqStub = requestStub();
-    reqStub.headers['content-length'] = 1000000000;
-    checkTypeSizeAndDuplication(reqStub, newUploadedFile, callbackSpy);
-    expect(callbackSpy.calledWith(null, false)).to.be.true;
-  });
+    it('uploads file if it has no issues', () => {
+        const newUploadedFile = {
+            originalname: 'file1.pdf',
+            mimetype: 'application/pdf',
+        };
+        checkTypeSizeAndDuplication(
+            requestStub(),
+            newUploadedFile,
+            callbackSpy
+        );
+        expect(callbackSpy.calledWith(null, true)).to.be.true;
+    });
 
-  it("does not upload the file if it is the wrong format", () => {
-    const newUploadedFile = {
-      originalname: "file3.pdf",
-      mimetype: "image/png",
-    };
-    checkTypeSizeAndDuplication(requestStub(), newUploadedFile, callbackSpy);
-    expect(callbackSpy.calledWith(null, false)).to.be.true;
-  });
+    it('does not upload the file if it is the wrong format', () => {
+        const newUploadedFile = {
+            originalname: 'file3.pdf',
+            mimetype: 'image/png',
+        };
+        checkTypeSizeAndDuplication(
+            requestStub(),
+            newUploadedFile,
+            callbackSpy
+        );
+        expect(callbackSpy.calledWith(null, false)).to.be.true;
+    });
 
-  it("does not upload the file if it has already been uploaded", () => {
-    const previouslyUploadedFiles = [
-      {
-        filename: "file3.pdf",
-        mimetype: "application/pdf",
+    it('does not upload the file if it has already been uploaded', () => {
+        const previouslyUploadedFiles = [
+            {
+                filename: 'file3.pdf',
+                mimetype: 'application/pdf',
+            },
+        ];
+        const newUploadedFile = {
+            originalname: 'file3.pdf',
+            mimetype: 'application/pdf',
+        };
+        checkTypeSizeAndDuplication(
+            requestStub(previouslyUploadedFiles),
+            newUploadedFile,
+            callbackSpy
+        );
+        expect(callbackSpy.calledWith(null, false)).to.be.true;
+    });
 
-      },
-    ];
-    const newUploadedFile = {
-      originalname: "file3.pdf",
-      mimetype: "application/pdf",
-    };
-    checkTypeSizeAndDuplication(
-      requestStub(previouslyUploadedFiles),
-      newUploadedFile,
-      callbackSpy
-    );
-    expect(callbackSpy.calledWith(null, false)).to.be.true;
-  });
+    it('delete file and send error message if it is too large', () => {
+        // when
+        const unlinkFile = sandbox.stub(fs, 'unlink').callsFake(() => null);
+        const reqStub = {
+            files: [
+                {
+                    size: 210_000_000,
+                    originalname: 'file_1.pdf',
+                },
+                {
+                    size: 210_000_000,
+                    originalname: 'file_2.pdf',
+                },
+            ],
+            session: {
+                eApp: {
+                    uploadedFileData: [
+                        {
+                            filename: 'file_1.pdf',
+                            storageName: 'file_1.pdf',
+                        },
+                        {
+                            filename: 'file_2.pdf',
+                            storageName: 'file_2.pdf',
+                        },
+                    ],
+                    uploadMessages: {
+                        errors: [],
+                    },
+                },
+            },
+            _sails: {
+                config: {
+                    eAppS3Vals: {
+                        s3_bucket: 'leg-demo-upload-d4szp8',
+                    },
+                },
+            },
+        };
+        displayErrorAndRemoveLargeFiles(reqStub);
+
+        // then
+        expect(reqStub.session.eApp.uploadedFileData.length).to.equal(0);
+        expect(reqStub.session.eApp.uploadMessages.errors.length).to.equal(2);
+        expect(unlinkFile.callCount).to.equal(2);
+
+    });
 });

--- a/tests/specs/helpers/uploadedFileErrorChecks.test.js
+++ b/tests/specs/helpers/uploadedFileErrorChecks.test.js
@@ -120,6 +120,5 @@ describe('checkTypeSizeAndDuplication', () => {
         expect(reqStub.session.eApp.uploadedFileData.length).to.equal(0);
         expect(reqStub.session.eApp.uploadMessages.errors.length).to.equal(2);
         expect(unlinkFile.callCount).to.equal(2);
-
     });
 });

--- a/views/eApostilles/uploadFiles.ejs
+++ b/views/eApostilles/uploadFiles.ejs
@@ -29,6 +29,9 @@
     <% if (fileCountError) { %>
         <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
             data-module="govuk-error-summary">
+            <h2 class="govuk-error-summary__title" id="error-summary-title">
+                There is a problem
+            </h2>
             <div class="govuk-error-summary__body">
                 <ul class="govuk-list govuk-error-summary__list">
                     <li>
@@ -43,6 +46,9 @@
     <% if (infectedFiles.length > 0) { %>
         <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
             data-module="govuk-error-summary">
+            <h2 class="govuk-error-summary__title" id="error-summary-title">
+                There is a problem
+            </h2>
             <div class="govuk-error-summary__body">
                 <ul class="govuk-list govuk-error-summary__list">
                     <li>


### PR DESCRIPTION
# Description


https://user-images.githubusercontent.com/1377253/134202781-d9a2f3e6-a0d5-4dc2-95cd-dff5295c81e1.mp4

This is a bug ticket that fixes an issue where upload limits are being calculated as an aggregate instead of per file.

Below is a screenshot showing what happens when two large pdfs (190MB) are uploaded with the new change, they are deleted and this error message is presented.

---

<img width="970" alt="Screenshot 2021-09-21 at 16 44 10" src="https://user-images.githubusercontent.com/1377253/134203582-7738fb49-eb31-4ea1-8223-c99e70c93088.png">

---

Here is the link from the video with the multer issue --> https://github.com/expressjs/multer/issues/344

**Jira ticket** https://jira.digital.csd.fcdo.gov.uk/browse/EIA-174

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual end-to-end
- [x] Unit tests

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes