### PR TITLE
Feat/eia 286 hide info rejected

### DIFF
--- a/api/controllers/OpenEAppController.js
+++ b/api/controllers/OpenEAppController.js
@@ -69,7 +69,7 @@ const OpenEAppController = {
                 applicationExpired,
                 applicationStatus: casebookStatus,
                 allDocumentsRejected:
-                    noOfRejectedDocs == casebookDocuments.length,
+                    noOfRejectedDocs === casebookDocuments.length,
             });
         } catch (error) {
             sails.log.error(error);
@@ -98,6 +98,12 @@ const OpenEAppController = {
         }
         if (!casebookResponse.payment) {
             throw new Error('No payment info found from Casebook');
+        }
+        if (
+            !casebookResponse.payment.transactions ||
+            casebookResponse.payment.transactions.length === 0
+            ) {
+            throw new Error('No payment transactions found from Casebook');
         }
 
         return {

--- a/tests/specs/controllers/OpenEAppController.test.js
+++ b/tests/specs/controllers/OpenEAppController.test.js
@@ -401,7 +401,7 @@ describe.only('OpenEAppController', () => {
             }));
             sandbox
                 .stub(Date, 'now')
-                .callsFake(() => TWO_DAYS_AFTER_COMPLETION);
+                .callsFake(() => TWELVE_DAYS_AFTER_COMPLETION);
             findApplicationData = sandbox
                 .stub(Application, 'find')
                 .resolves(resolvedAppData);

--- a/tests/specs/controllers/OpenEAppController.test.js
+++ b/tests/specs/controllers/OpenEAppController.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const OpenEAppController = require('../../../api/controllers/OpenEAppController');
 const CasebookService = require('../../../api/services/CasebookService');
 
-describe.only('OpenEAppController', () => {
+describe('OpenEAppController', () => {
     const sandbox = sinon.sandbox.create();
     let reqStub;
     let resStub;

--- a/views/eApostilles/openEApp.ejs
+++ b/views/eApostilles/openEApp.ejs
@@ -5,7 +5,7 @@
         <%- partial ('../partials/inner-header.ejs')%>
     </div>
 
-    <% if (applicationStatus === 'Completed' && !applicationExpired) { %>
+    <% if (applicationStatus === 'Completed' && !applicationExpired && !allDocumentsRejected) { %>
         <div class="column-two-thirds">
             <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
                 data-module="govuk-notification-banner">
@@ -48,7 +48,7 @@
                     have
                     them legalised again. You will have to pay for each uploaded PDF.
                 </p>
-            <% } else { %>
+            <% } else if (!allDocumentsRejected) { %>
                 <p>
                     You can now download PDF versions of the legalised documents.
                 </p>


### PR DESCRIPTION
## Description

This ticket essentially hides all the important copy from an application page if all the documents are rejected because we currently don't have any text for it.

<img width="888" alt="Screenshot 2021-11-29 at 11 30 34" src="https://user-images.githubusercontent.com/1377253/144044148-6648c08c-b3e0-4eb5-9c32-9042d64149ed.png">

---

Instead of this:

<img width="858" alt="Screenshot 2021-11-30 at 12 07 24" src="https://user-images.githubusercontent.com/1377253/144044559-46157cd0-f267-4d89-b822-fbd12afde44a.png">

---

This is supposed to be a quick and dirty fix, at some point we will get a content p[erson to write some copy specifically for this scenario.
