### PR TITLE
Look into issue where ClamAV aborts mid scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,5 +162,3 @@ uploads
 test-results.xml
 a11y-test-results.xml
 cypress/screenshots
-
-tests/env.vars

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ uploads
 test-results.xml
 a11y-test-results.xml
 cypress/screenshots
+
+tests/env.vars

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ From Keybase, drop each services .env file into the root of the appropriate repo
 
 Install node modules in each repo
 
-`npm -i`
+`npm i`
 
 _NOTE: If you are using an M1 Mac you'll have to install node-sass via Rosetta_
 

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -4,10 +4,11 @@ const sails = require('sails');
 const uploadFileToStorage = require('../helpers/uploadFileToStorage');
 const deleteFileFromStorage = require('../helpers/deleteFileFromStorage');
 const {
-    virusScanAndCheckFiletype,
+    virusScan,
     checkTypeSizeAndDuplication,
     displayErrorAndRemoveLargeFiles,
     connectToClamAV,
+    checkFileType,
 } = require('../helpers/uploadedFileErrorChecks');
 
 const FORM_INPUT_NAME = 'documents';
@@ -74,7 +75,9 @@ const FileUploadController = {
             }
             sails.log.error(err);
         } else {
-            await virusScanAndCheckFiletype(req);
+            await checkFileType(req);
+            await virusScan(req);
+
             !inDevEnvironment &&
                 FileUploadController._addS3LocationToSession(req);
         }

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -75,14 +75,25 @@ const FileUploadController = {
             }
             sails.log.error(err);
         } else {
+            await FileUploadController._fileTypeAndVirusScan(req, res);
+        }
+
+        FileUploadController._redirectToUploadPage(res);
+    },
+
+    async _fileTypeAndVirusScan(req, res) {
+        try {
             await checkFileType(req, res);
             await virusScan(req, res);
 
             !inDevEnvironment &&
                 FileUploadController._addS3LocationToSession(req);
+        } catch (err) {
+            sails.log.error(err);
+            if (!err.message.includes('STAYONPAGE')) {
+                res.view('eApostilles/fileUploadError.ejs');
+            }
         }
-
-        FileUploadController._redirectToUploadPage(res);
     },
 
     _addS3LocationToSession(req) {

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -75,8 +75,8 @@ const FileUploadController = {
             }
             sails.log.error(err);
         } else {
-            await checkFileType(req);
-            await virusScan(req);
+            await checkFileType(req, res);
+            await virusScan(req, res);
 
             !inDevEnvironment &&
                 FileUploadController._addS3LocationToSession(req);

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -40,11 +40,9 @@ const FileUploadController = {
     uploadFileHandler(req, res) {
         FileUploadController._clearExistingErrorMessages(req);
         const uploadFileWithMulter = FileUploadController._multerSetup(req);
-        uploadFileWithMulter(req, res, async (err) => {
+        uploadFileWithMulter(req, res, (err) => {
             sails.log.info('File successfully uploaded.');
             FileUploadController._errorChecksAfterUpload(req, res, err);
-            await FileUploadController._fileTypeAndVirusScan(req, res);
-            FileUploadController._redirectToUploadPage(res);
         });
     },
 
@@ -69,7 +67,7 @@ const FileUploadController = {
         req.session.eApp.uploadMessages.noFileUploadedError = false;
     },
 
-    _errorChecksAfterUpload(req, res, err) {
+    async _errorChecksAfterUpload(req, res, err) {
         try {
             if (req.files.length === 0) {
                 req.session.eApp.uploadMessages.noFileUploadedError = true;
@@ -81,6 +79,7 @@ const FileUploadController = {
         } catch (err) {
             sails.log.error(err);
             FileUploadController._redirectToUploadPage(res);
+            return;
         }
 
         if (err) {
@@ -92,6 +91,9 @@ const FileUploadController = {
                 sails.log.error(err);
                 res.serverError(err);
             }
+        } else {
+            await FileUploadController._fileTypeAndVirusScan(req, res);
+            FileUploadController._redirectToUploadPage(res);
         }
     },
 

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -65,6 +65,12 @@ const FileUploadController = {
     },
 
     async _errorChecksAfterUpload(req, res, err) {
+        if (req.files.length === 0) {
+            req.session.eApp.uploadMessages.noFileUploadedError = true;
+            sails.log.error('No files were uploaded.');
+            return;
+        }
+
         displayErrorAndRemoveLargeFiles(req);
         if (err) {
             const fileLimitExceeded = err.code === MULTER_FILE_COUNT_ERR_CODE;

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -10,7 +10,7 @@ const {
     removeLargeFiles,
     connectToClamAV,
     checkFileType,
-    UserAdressableError
+    UserAdressableError,
 } = require('../helpers/uploadedFileErrorChecks');
 
 const FORM_INPUT_NAME = 'documents';
@@ -68,27 +68,21 @@ const FileUploadController = {
     },
 
     async _errorChecksAfterUpload(req, res, err) {
-        try {
-            if (req.files.length === 0) {
-                req.session.eApp.uploadMessages.noFileUploadedError = true;
-                throw new Error('No files were uploaded.');
-            }
+        const hasNoFiles = req.files.length === 0;
 
-            removeLargeFiles(req);
-
-        } catch (err) {
-            sails.log.error(err);
+        if (hasNoFiles) {
+            req.session.eApp.uploadMessages.noFileUploadedError = true;
+            sails.log.error('No files were uploaded.');
             FileUploadController._redirectToUploadPage(res);
-            return;
         }
 
+        removeLargeFiles(req);
+
         if (err) {
-            const fileLimitExceeded =
-                err.code === MULTER_FILE_COUNT_ERR_CODE;
+            const fileLimitExceeded = err.code === MULTER_FILE_COUNT_ERR_CODE;
             if (fileLimitExceeded) {
                 req.session.eApp.uploadMessages.fileCountError = true;
             } else {
-                sails.log.error(err);
                 res.serverError(err);
             }
         } else {

--- a/api/helpers/uploadFileToStorage.js
+++ b/api/helpers/uploadFileToStorage.js
@@ -1,7 +1,10 @@
+// @ts-check
 const multerS3 = require('multer-s3');
 const multer = require('multer');
 const AWS = require('aws-sdk');
 const path = require("path");
+const sails = require("sails");
+const fs = require("fs");
 const s3 = new AWS.S3();
 
 const inDevEnvironment = process.env.NODE_ENV === 'development';
@@ -13,7 +16,7 @@ function uploadFileToStorage(s3BucketName) {
 }
 
 function uploadFileLocally() {
-    const uploadFolder = path.resolve(__dirname, 'uploads/');
+    const uploadFolder = path.resolve('./', 'uploads/');
     const options = {
         destination: (_req, _file, cb) => cb(null, uploadFolder),
         filename: (req, file, cb) => generateFileData(req, file, cb),
@@ -21,12 +24,13 @@ function uploadFileLocally() {
 
     if (!fs.existsSync(uploadFolder)){
         fs.mkdirSync(uploadFolder);
+        sails.log.info('Uploads folder created.');
     }
 
     return multer.diskStorage(options);
 }
 
-function uploadFileToS3(s3BucketName, ) {
+function uploadFileToS3(s3BucketName) {
     const options = {
         s3,
         bucket: s3BucketName,

--- a/api/helpers/uploadFileToStorage.js
+++ b/api/helpers/uploadFileToStorage.js
@@ -1,6 +1,7 @@
 const multerS3 = require('multer-s3');
 const multer = require('multer');
 const AWS = require('aws-sdk');
+const path = require("path");
 const s3 = new AWS.S3();
 
 const inDevEnvironment = process.env.NODE_ENV === 'development';
@@ -12,10 +13,16 @@ function uploadFileToStorage(s3BucketName) {
 }
 
 function uploadFileLocally() {
+    const uploadFolder = path.resolve(__dirname, 'uploads/');
     const options = {
-        destination: (req, file, cb) => cb(null, 'uploads/'),
+        destination: (_req, _file, cb) => cb(null, uploadFolder),
         filename: (req, file, cb) => generateFileData(req, file, cb),
     };
+
+    if (!fs.existsSync(uploadFolder)){
+        fs.mkdirSync(uploadFolder);
+    }
+
     return multer.diskStorage(options);
 }
 

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -57,7 +57,8 @@ async function checkFileType(req) {
                 : await checkS3FileType(file, req);
         }
     } catch (err) {
-        sails.log.error(`checkFileType Error: ${err}`);
+        sails.log.error(`checkFileType ${err}`);
+        return res.view('eApostilles/fileUploadError.ejs');
     }
 }
 
@@ -72,7 +73,7 @@ async function checkLocalFileType(file, req) {
     }
 }
 
-async function checkS3FileType() {
+async function checkS3FileType(file, req) {
     try {
         const storageName = getStorageNameFromSession(file, req);
         const s3Bucket = req._sails.config.upload.s3_bucket;
@@ -106,6 +107,7 @@ async function virusScan(req) {
         }
     } catch (err) {
         sails.log.error(`virusScan Error: ${err}`);
+        return res.view('eApostilles/fileUploadError.ejs');
     }
 }
 

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -19,7 +19,7 @@ let clamscan;
 const UPLOAD_ERROR = {
     incorrectFileType: 'The file is not a PDF',
     fileInfected: 'The file is infected with a virus',
-}
+};
 
 async function connectToClamAV(req) {
     try {
@@ -69,7 +69,7 @@ async function checkFileType(req) {
                 : await checkS3FileType(file, req);
         }
     } catch (err) {
-        if (err.message === UPLOAD_ERROR.incorrectFileType) {
+        if (err.message === `Error: ${UPLOAD_ERROR.incorrectFileType}`) {
             throw new UserAdressableError(`checkFileType ${err}`);
         }
         throw new Error(`checkFileType ${err}`);
@@ -122,7 +122,7 @@ async function virusScan(req) {
                 : await scanStreamOfS3File(file, req);
         }
     } catch (err) {
-        if (err.message === UPLOAD_ERROR.fileInfected) {
+        if (err.message === `Error: ${UPLOAD_ERROR.fileInfected}`) {
             throw new UserAdressableError(`virusScan ${err}`);
         }
         throw new Error(`virusScan ${err}`);
@@ -349,7 +349,7 @@ function formatFileSizeMb(bytes, decimalPlaces = 1) {
 class UserAdressableError extends Error {
     constructor(message) {
         super(message);
-        this.name = "UserAdressableError";
+        this.name = 'UserAdressableError';
     }
 }
 

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -88,13 +88,15 @@ async function checkS3FileType(file, req) {
 }
 
 async function virusScan(req) {
-    try {
-        sails.log.info('Scanning for viruses...');
-        if (req.files.length === 0) {
-            req.session.eApp.uploadMessages.noFileUploadedError = true;
-            throw new Error('No files were uploaded.');
-        }
+    sails.log.info('Scanning for viruses...');
 
+    if (req.files.length === 0) {
+        req.session.eApp.uploadMessages.noFileUploadedError = true;
+        sails.log.error('No files were uploaded.');
+        return;
+    }
+
+    try {
         clamscan = await initialiseClamScan(req);
         if (!clamscan) {
             throw new Error('Not connected to clamAV');

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -2,8 +2,8 @@ const NodeClam = require('clamscan');
 const { resolve } = require('path');
 const FileType = require('file-type');
 const { makeTokenizer } = require('@tokenizer/s3');
-const AWS = require('aws-sdk');
-const s3 = new AWS.S3();
+const { S3Client } = require('@aws-sdk/client-s3');
+const s3 = new S3Client({});
 
 const deleteFileFromStorage = require('./deleteFileFromStorage');
 

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -1,9 +1,13 @@
+// @ts-check
 const NodeClam = require('clamscan');
+const sails = require('sails');
 const { resolve } = require('path');
 const FileType = require('file-type');
 const { makeTokenizer } = require('@tokenizer/s3');
 const { S3Client } = require('@aws-sdk/client-s3');
-const s3 = new S3Client({});
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3();
+const s3Client = new S3Client({});
 
 const deleteFileFromStorage = require('./deleteFileFromStorage');
 
@@ -79,13 +83,13 @@ async function checkLocalFileType(file, req) {
 }
 
 /**
- * @ref https://github.com/UKForeignOffice/loi-application-service/blob/develop/docs/how-file-upload-works.md
+ * @ref https://github.com/sindresorhus/file-type#filetypefromtokenizertokenizer
  */
 async function checkS3FileType(file, req) {
     try {
         const storageName = getStorageNameFromSession(file, req);
         const s3Bucket = req._sails.config.upload.s3_bucket;
-        const s3Tokenizer = await makeTokenizer(s3, {
+        const s3Tokenizer = await makeTokenizer(s3Client, {
             Bucket: s3Bucket,
             Key: storageName
         });

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -89,7 +89,7 @@ async function checkS3FileType(file, req) {
             Bucket: s3Bucket,
             Key: storageName
         });
-        const fileType = await FileType.fileTypeFromTokenizer(s3Tokenizer);
+        const fileType = await FileType.fromTokenizer(s3Tokenizer);
 
         deleteIfNotPDF(file, req, fileType);
     } catch (err) {

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -78,6 +78,9 @@ async function checkLocalFileType(file, req) {
     }
 }
 
+/**
+ * @ref https://github.com/UKForeignOffice/loi-application-service/blob/develop/docs/how-file-upload-works.md
+ */
 async function checkS3FileType(file, req) {
     try {
         const storageName = getStorageNameFromSession(file, req);

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -48,7 +48,7 @@ function initialiseClamScan(req) {
     return new NodeClam().init(clamAvOptions);
 }
 
-async function checkFileType(req) {
+async function checkFileType(req, res) {
     try {
         sails.log.info('Checking file type...');
         for (const file of req.files) {
@@ -87,7 +87,7 @@ async function checkS3FileType(file, req) {
     }
 }
 
-async function virusScan(req) {
+async function virusScan(req, res) {
     sails.log.info('Scanning for viruses...');
 
     if (req.files.length === 0) {

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -104,12 +104,6 @@ async function checkS3FileType(file, req) {
 async function virusScan(req) {
     sails.log.info('Scanning for viruses...');
 
-    if (req.files.length === 0) {
-        req.session.eApp.uploadMessages.noFileUploadedError = true;
-        sails.log.error('No files were uploaded.');
-        return;
-    }
-
     try {
         clamscan = await initialiseClamScan(req);
         if (!clamscan) {

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -17,8 +17,8 @@ const inDevEnvironment = process.env.NODE_ENV === 'development';
 let clamscan;
 
 const UPLOAD_ERROR = {
-    1001: 'The file is not a PDF',
-    1002: 'The file is infected with a virus',
+    incorrectFileType: 'The file is not a PDF',
+    fileInfected: 'The file is infected with a virus',
 }
 
 async function connectToClamAV(req) {
@@ -69,7 +69,7 @@ async function checkFileType(req) {
                 : await checkS3FileType(file, req);
         }
     } catch (err) {
-        if (err.message === UPLOAD_ERROR[1001]) {
+        if (err.message === UPLOAD_ERROR.incorrectFileType) {
             throw new UserAdressableError(`checkFileType ${err}`);
         }
         throw new Error(`checkFileType ${err}`);
@@ -122,7 +122,7 @@ async function virusScan(req) {
                 : await scanStreamOfS3File(file, req);
         }
     } catch (err) {
-        if (err.message === UPLOAD_ERROR[1002]) {
+        if (err.message === UPLOAD_ERROR.fileInfected) {
             throw new UserAdressableError(`virusScan ${err}`);
         }
         throw new Error(`virusScan ${err}`);
@@ -175,7 +175,7 @@ function addErrorToSessionIfNotPDF(file, req, fileType) {
         addErrorsToSession(req, file, [
             'The file is in the wrong file type. Only PDF files are allowed.',
         ]);
-        throw new Error(UPLOAD_ERROR[1001]);
+        throw new Error(UPLOAD_ERROR.incorrectFileType);
     }
 }
 
@@ -213,7 +213,7 @@ function scanResponses(scanResults, file, req = null, forS3 = false) {
     const { isInfected, viruses } = scanResults;
     if (isInfected) {
         addInfectedFilenameToSessionErrors(req, file);
-        throw new Error(UPLOAD_ERROR[1002]);
+        throw new Error(UPLOAD_ERROR.fileInfected);
     }
 
     sails.log.info(`${file.originalname} is not infected.`);

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -1,6 +1,7 @@
 const NodeClam = require('clamscan');
 const { resolve } = require('path');
 const FileType = require('file-type');
+const { makeTokenizer } = require('@tokenizer/s3');
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3();
 
@@ -81,9 +82,11 @@ async function checkS3FileType(file, req) {
     try {
         const storageName = getStorageNameFromSession(file, req);
         const s3Bucket = req._sails.config.upload.s3_bucket;
-        const fileType = await FileType.fromStream(
-            getS3FileStream(storageName, s3Bucket)
-        );
+        const s3Tokenizer = await makeTokenizer(s3, {
+            Bucket: s3Bucket,
+            Key: storageName
+        });
+        const fileType = await FileType.fileTypeFromTokenizer(s3Tokenizer);
 
         deleteIfNotPDF(file, req, fileType);
     } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
             "name": "FCO-LOI-Service",
             "version": "0.0.1",
             "dependencies": {
-                "@aws-sdk/client-s3": "^3.48.0",
                 "@tokenizer/s3": "^0.2.0",
                 "amqplib": "^0.5.1",
                 "aws-sdk": "^2.940.0",
@@ -128,6 +127,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
             "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -137,12 +137,14 @@
         "node_modules/@aws-crypto/crc32/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "peer": true
         },
         "node_modules/@aws-crypto/ie11-detection": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
             "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -150,12 +152,14 @@
         "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "peer": true
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -170,12 +174,14 @@
         "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "peer": true
         },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -185,12 +191,14 @@
         "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "peer": true
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
             "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -198,12 +206,14 @@
         "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "peer": true
         },
         "node_modules/@aws-crypto/util": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
             "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.1.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -213,12 +223,14 @@
         "node_modules/@aws-crypto/util/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "peer": true
         },
         "node_modules/@aws-sdk/abort-controller": {
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.47.2.tgz",
             "integrity": "sha512-OpxsJ3b2KlpqTQKq6Py6JtLhA7KaAtHthH1JLLWStaFhU5/Js8nFnfPWdJIDRLpuAGyeRTbkjOEUsOkWAI5dAw==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -231,6 +243,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.47.1.tgz",
             "integrity": "sha512-D8wcAumX+q/VlX6lbYHWJqsaDBvj1BHVjJlBwLPrUBcsk0bRaJhhbhesej6DkhRX2pFhwXlHgc7CAgYhJCtc/w==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             }
@@ -239,6 +252,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.47.2.tgz",
             "integrity": "sha512-29+ZWESaFDQ9QXo7RGcUMuP89GTKo8bKlYplzNsO/B1uG17LgTgVHBapU3UBlF/EkOh1rzN5tEW+XwwstHvlXg==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/util-base64-browser": "3.47.1",
                 "tslib": "^2.3.0"
@@ -248,6 +262,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.48.0.tgz",
             "integrity": "sha512-zOr7WWr9b5V3nTQnMTz+kjDpLJceI5Vmx3+mwi5a3vFDwJBvMJK0C25A9koDXtrjn8/hszAePh6+rC0oW8QJsQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -307,6 +322,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.48.0.tgz",
             "integrity": "sha512-A9f7B5k+X7bx062OQEcLHIMMIq0H1GlUqdw9xReCLd6W6vcRthbeSK5xbkM7TzHeKHE2/9qQYAy0lyKkxFE6bQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -347,6 +363,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.48.0.tgz",
             "integrity": "sha512-vOSIYCHjXB9nztZqwjIjV/jRZCfgej1YHpgqeNlfL8hPNhcrHemaoJaKHRPnhljIuHi+H5yQW7Pm4qJUFtGwKA==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -392,6 +409,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.47.2.tgz",
             "integrity": "sha512-uv9U/qDOSqyCPQ71qiwMslqRMxYyt0y0h6X0aQ67GCPq4rbbU/dn8PqnYT0VfX/9Ss+DcbTm7vOTxVKv+8XADA==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/signature-v4": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -406,6 +424,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.47.2.tgz",
             "integrity": "sha512-HQKXY8y51kpTrD7P8fZJNf4MdCdu0+NcdOc+HScrQ21oZJv3BXUwXxKiOWY95Z3jYqyFwSKs1/FFuQ1mV0wjPg==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -419,6 +438,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.47.2.tgz",
             "integrity": "sha512-7fCIofgU5pdKGgbCAYQ8H7sIFluN3oebFyFy7C4eXJyNy/8QKjFHEW3NkNCh0Bkd5sLOqkwYU3nyRx0CbNkEoQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.47.2",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -434,6 +454,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.48.0.tgz",
             "integrity": "sha512-PSTfzK8V+3WVJOv+wlS4y09KYZx3iYj4Ad8LMGmGE4aqew8eRf6u2WuTmqrWwuOTxDra9PJ1ObcM5vBc+nZcYA==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -453,6 +474,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.48.0.tgz",
             "integrity": "sha512-7CrbUT7yEZvYSQNXxZWN5KUx355wD+xrYIafoEST28T7nwcIiu7l2zpBY3JPhPIPNXqryVKfNQJvKV1dP3wF4g==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -474,6 +496,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.47.2.tgz",
             "integrity": "sha512-LBuABkVt/tdSoHy8hdGVnInZx5QADhK90dEHc41+HTTP3bCSNsSBIErkZnmhAD/3AGz7m/4qkPmhJOqzFisY/g==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
@@ -489,6 +512,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.48.0.tgz",
             "integrity": "sha512-31Ill3ZW35dueXb09PpOJ4C8oKdRGypbnycAgLYvvqYlO4LOs9FyQAsw+t2+ExvE6DznM0vkeWTQI3y7HUVYCA==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/client-sso": "3.48.0",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -505,6 +529,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.47.2.tgz",
             "integrity": "sha512-biJo8zJwNk8Dwrd/mkTcu8iLuOlGbsG2Uahta4StkOUhZ733xewOZ4WISLXVLocb/PXLM1lZQgkobwugpFOQRA==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -518,6 +543,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.47.2.tgz",
             "integrity": "sha512-KRWpWBuICxIJOp5vPe2NzT387uW8Q5IpyMNf8SNmFe9a9yTrg2oIRKkbEHHRNyCRnjbDmpU3Td58V9bpmaBXGw==",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-sdk/types": "3.47.1",
@@ -529,6 +555,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.47.2.tgz",
             "integrity": "sha512-dXjJ0eoNCu9P6uOzNcIL0OoXhVbdR/LPTRJCIR7NcfGCmJ4ZXeYwgYcHFTosrT/+SXAFGgsoU23dqA63TFWlMQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/eventstream-serde-universal": "3.47.2",
@@ -543,6 +570,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.47.2.tgz",
             "integrity": "sha512-LE481skmmWqoPhGyhFWqf/0eEtAFKSJqyzPZEer6yFUpejaijek4Heo6B+Y3cyDGoASuqY4Wum+9q1Z1xPn2BQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -555,6 +583,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.47.2.tgz",
             "integrity": "sha512-hrEsbDFaRr7rNJw+qgua+YhkMgSkgR/YhBe+rdI20maaJARIjLo4C8eRqAqrmlE4i2+PU4CvM/fVdL9M3HQXfQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/eventstream-serde-universal": "3.47.2",
@@ -569,6 +598,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.47.2.tgz",
             "integrity": "sha512-Zkfa2kHKNsWSAdO4atr9+JPEtcZzWuJqZHMr8MO5aXAMnKd5BA9XvzyGyhrfpr9HmnoqcbXrcx8iqDxcFEIp5g==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -582,6 +612,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.47.2.tgz",
             "integrity": "sha512-MZwwKtJwkWPm3Tzh+F3gcts13v1OuZih0slOO4GJpMxq46+lcW4DoW04lNHULJsyduXs4CziH8g65DDh0Yhq6w==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/querystring-builder": "3.47.2",
@@ -594,6 +625,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.47.2.tgz",
             "integrity": "sha512-DG8kGFUqXH+eQLLQtzTuBxBEuLHJ03w3X2Geq7aNvfwh06OOJW3FYz+FTLH2f2HxqlKOQtf3MsqpH074zKC5/A==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/chunked-blob-reader": "3.47.1",
                 "@aws-sdk/chunked-blob-reader-native": "3.47.2",
@@ -605,6 +637,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.47.2.tgz",
             "integrity": "sha512-OpUCNGvchKI1WoOCtCm36gQtECMz2P5mJoXxAHNZQ5qQ69A5Vk/DZs1V24N94M7tl1u7ZpbLsJbWFdu+P4B27g==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-buffer-from": "3.47.2",
@@ -618,6 +651,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.47.2.tgz",
             "integrity": "sha512-ModP4kZkkj4j1djuANwETAwYL1uTcXBHVcVLvy/wVDVLIcEW1TgGBgkY0rSGFE4RWDESTjhLCBKNDgvpxReSLQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -630,6 +664,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.47.2.tgz",
             "integrity": "sha512-QLIp0Gv9IbSVXru1kS92M4kF9ZgHmVP7Us8dWSu5UC7LJt6Uxhxjb+e+F0h9qY1Z3Prior12I4r5COgVO3dWxA==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -639,6 +674,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.47.1.tgz",
             "integrity": "sha512-HQMvT3dP6DCjmn87WkzYxUF9RqkvuXgKfddLEKj/tg/OgDQJv9xIPjEEry8Fd36ncbBqaBmC/z2ETZhpzHQvXA==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -650,6 +686,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.47.2.tgz",
             "integrity": "sha512-APIz8mCPscYG6gCxvC2dbrBfpM3jHwAh+VqTmGHHxxO1AAP3y5ohtdl/2MsKtEPKuyT1IX2/YoUwcOyJj65xmw==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-utf8-browser": "3.47.1",
@@ -661,6 +698,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.47.2.tgz",
             "integrity": "sha512-sjZZZ7hOR9retsblYOs4cgsVg7r1Sfuvr/aIx16XXv3TeAk7fz8JTRf5STxMM6YkGIVMbvBOHpMNvcGGgJQhZQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -675,6 +713,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.47.2.tgz",
             "integrity": "sha512-VrUrkAUS3CqI7tK3r0c0oT+1SE1L+euyq6j6Jt3XOjRMUXCkArecVkr3jEprbpVDiAkaTXEJE77iL1+98twiYA==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -690,6 +729,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.47.2.tgz",
             "integrity": "sha512-rpLtN6BczAfJnH1fpXyUOMdDFN3xrky3QZ4SULVgTLXNMOvN5zDJnjwUh/QNgEaEQhxd6lroVJSgosG3357kWg==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -703,6 +743,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.47.2.tgz",
             "integrity": "sha512-sLv5q8+POzpMvp9dx/OInFr6VWJreHOGFoauYN1n7a+8dmhr9tycBLq/j+eBXI2FWwC3dXCBdrC9qs4ieSRe0Q==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-header-default": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -717,6 +758,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.47.2.tgz",
             "integrity": "sha512-fCcQaQ/ac+h8nS8d8nSrvP/scNTCdkHQ8PpNXo7nSz4a67xbxxln61T4iHOin8z0m62NlFrhtMdlQTtDqDEZVg==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -730,6 +772,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.47.2.tgz",
             "integrity": "sha512-sDIGydvdO1LC7VQntTDMK+YYLRVCJAhrsCT8SxyAX0Jhu7Ek1BfRZzSZDwapL+idbMyyKsB80NpNoTWuKRrrew==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -743,6 +786,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.47.2.tgz",
             "integrity": "sha512-b6ozPYnInQB1Iv+UjLyhunTCUcw54AKtUO7Mj2QLT2GqCPDPry7ZmAC9Qtfv4Itv7HyM4VfR1roAGKZwT4zxQw==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -755,6 +799,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.47.2.tgz",
             "integrity": "sha512-Oz14cAaYmtzMYw0/ehlVLvMF4gqQS0qaYWGyyR4a3nONiwEDzxNMEQiEg7i8VgsP4usK7lfYZLXgwSmqo7uCzg==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -767,6 +812,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.47.2.tgz",
             "integrity": "sha512-qgAE/+hVGXQDkqbVo+uFeb+N7mr7kBi0Oc1Fm490fm3uLQnXuyu3suIix//wxNejoLwIgKQGSLrQNgnXtuvhxw==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/service-error-classification": "3.47.2",
@@ -782,6 +828,7 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "peer": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -790,6 +837,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.47.2.tgz",
             "integrity": "sha512-KjcrHHDIn4QCh8pTRVT2u8uOnpdPYVB2p+xblwyRvJt2VLhgJbgNpRy8pOwNo2lyfbOKrmWeBk4x0NduiXle8g==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/signature-v4": "3.47.2",
@@ -808,6 +856,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.47.2.tgz",
             "integrity": "sha512-KlO4cYb4Bxf/Jg/uxlxRrFvxUR/DmjMIS+JRZNGqK4XyYA+apYZkfM0XUtMiKc491n/euluf9A0AyTxpMgixxg==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-signing": "3.47.2",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -824,6 +873,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.47.2.tgz",
             "integrity": "sha512-Gjw+fkG4UvvbP5LrGW1FzUq0IJB6QIBFxStE0gbyjkKNYtcb9c0R3dIwH5CSECtelDZScytwmBKaVe8NGi6wJA==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -836,6 +886,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.47.2.tgz",
             "integrity": "sha512-r6/2gf5gwkVdI7EOa1TdYdfzOdCF3jkhjLi98c3nAxZNxZFGwoycIy7Bd6sCfOdcmk8NyVmR0APpsgD9q+a3nw==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -851,6 +902,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.47.2.tgz",
             "integrity": "sha512-dRNQJjvlg4omfhAfSYtZva4OpS/58aLO7y8l2o5sQHGPwob5OYO5zfPioi4h68UZw1fagG962hUywOkVJDJAuw==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -863,6 +915,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.47.2.tgz",
             "integrity": "sha512-9wedI1L92stvg5fs6Y3CbUXYLZIYdI3Mrdqex+ulNRuepgZNORsk+dnb8rTkf9cO3nuWRrnfKBLc/uiTcA1dww==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -874,6 +927,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.47.2.tgz",
             "integrity": "sha512-LF5gOi37lJ3tkuDSqZVKHmqYY8oTIUTEdmPVUbBQtPKsx9xfCNbMNVAP+C+7bnbt6StZIZsvtu0M144yNFXPGQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -887,6 +941,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.47.2.tgz",
             "integrity": "sha512-POdigo6ZXLRVWhmjE21Y1Q1ziPnM/c3rH0wHgzAtdx0Mfn6/9jS77QHMkZzC8MJ7lzgXVFDWM25evVZqdYrh+g==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
@@ -901,6 +956,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.47.2.tgz",
             "integrity": "sha512-X2Y+H2DBoeDnrSe5rsVc63uhext230AuG/+hIFHK2/HkyG9DiiHKNCNj2w8N4FLWEX3l8KDif3C7BqYxj9ZkDg==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -916,6 +972,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.47.2.tgz",
             "integrity": "sha512-0NiVJ6+JtRC8XOvNb1ofHtsjINrinC1/fDKvl/bDtJDhehC5EcIeiDQmHFUhGsgTyD+VpmuHj7E4AlV6BchNPQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -928,6 +985,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.47.2.tgz",
             "integrity": "sha512-XAQFbSigJD0fk61nSR6y6TMv3+o1IjymltWuDmGEtoI25pisC2M3A+3/xO9YHag/41CSgt9nQ+lh1iC4UlKKJw==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -940,6 +998,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.47.2.tgz",
             "integrity": "sha512-rsckQ262jFSDVES6rOuTnSDM9XEbM57zxeBj5BtD6eCnyUD0G4FZa1xZRum4khoxfff6/eJ+i2uncKrEk1v+EQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-uri-escape": "3.47.1",
@@ -953,6 +1012,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.47.2.tgz",
             "integrity": "sha512-28BirdFhZ+Y2pUMuI9r1ATgcQyt4q3cSqqpLSy7ADGb7xHde6oA/ZfRdX/s7OVIHoAfhrjAeI+TbYjwso9F/HA==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -965,6 +1025,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.47.2.tgz",
             "integrity": "sha512-oJCJbAPYhTNguJUhD8hlD7ibWIDpkvGrhkcq89gxBcXHPl/2/kjsii0gr302IH452IJlumpVe5wOXoZeqZYjaw==",
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             }
@@ -973,6 +1034,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.47.1.tgz",
             "integrity": "sha512-f0eVOMYkT4H0gOf1B9lw65/xeTa7rT9hocVB7DbjWk8Ifv46Uvlb4ZyYOLZIBDQyFNFrD/HHvja3BkzfV0MEOA==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -984,6 +1046,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.47.2.tgz",
             "integrity": "sha512-zJIhUY8LLiQldfM9wpgVw525dHbILJovyZm3xmm6Tq/t258cawNaeOvOp9w0I3ycA3gs+nKgMXdeMjLH8QLbWg==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "@aws-sdk/types": "3.47.1",
@@ -1017,6 +1080,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.47.2.tgz",
             "integrity": "sha512-vCzZodWyKmLzC+N/B1GzDjKD8I5b/ILTwPHaaH7yJdncISq/3jyTMJVW7mZHbDX61a18rL/bADnIxEd524Y2hQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-stack": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -1030,6 +1094,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.1.tgz",
             "integrity": "sha512-c+lxJJLD5Bq8HkrgaIWQfK8oGH53CYpRRJizyQ5qfRo9aXp/qshUnIVcgnA8t0k7jfzcIfa0Q7jSSBw3EerEbg==",
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             }
@@ -1038,6 +1103,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.47.2.tgz",
             "integrity": "sha512-xapm+8toLY1FJmdGWl/YWCGSbbzPitiKmcg9+NP1DIyZyHjzeG5vBZ2SYejYtGOf+Qn1VKyNN2+Qs049FOsh6w==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/querystring-parser": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -1048,6 +1114,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.47.1.tgz",
             "integrity": "sha512-Q+tZjYyBeWMyPJ6+l42JXS7gt5crXywJbLDGjoLoS+Ba0JDB5zp8IMRLzGzQpTO+VnbL4ZyEEUVEihyqFbB0iw==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1059,6 +1126,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.47.1.tgz",
             "integrity": "sha512-asStae2d1xvgs3czWvvVb4JWHfY2iV8yximL4MwF+Lb8XG/b8LH3tG1E5axAFVMBcljdvRB941N7w3rug7V9ig==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             }
@@ -1067,6 +1135,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.47.2.tgz",
             "integrity": "sha512-0Oml66+9/uERV1dosecA/1tEd0zdiwI3kEobCF5w2f4gJDzUdaEoztcRwtbLcFv6yVT7XoW4evMQbtlcruypcQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.47.2",
                 "tslib": "^2.3.0"
@@ -1079,6 +1148,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.47.1.tgz",
             "integrity": "sha512-qR307MATPC+4JtN7W9sSkchfdB3O4mulLKRpk7rF6Ns6vVwhaPfJstSGe9Qa68zYZXubF9h5WnoWuJz4N0Vqdw==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             }
@@ -1087,6 +1157,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.47.1.tgz",
             "integrity": "sha512-U2K7+gi3bAQBb3WB1/trvA+4rPC2SKH9w/sRtqBwtxHNOjXjiCiF3oEYnbir7cdSfhzMH4HBYKbfkHZwTAHMfw==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1098,6 +1169,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.47.2.tgz",
             "integrity": "sha512-oLytLGiIeJEk7FcT7bdeQNv7+vvVVPuL5hyXlCjHZwoWuDxepjoDhTaIC9Isq1UyPKfSZaVpk/1nqREe4aYDHw==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "tslib": "^2.3.0"
@@ -1110,6 +1182,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.47.1.tgz",
             "integrity": "sha512-kBs+YghZaOqChxLZDTR8dw5RQxJ/qF064EjRpC+TdCegLCO2UtZ97RXBvc5mdt94OxXGjGUjDiD/eAlpjjFNXw==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1121,6 +1194,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.47.2.tgz",
             "integrity": "sha512-C0L8pfZkJyWfuvLVRcM2Ff11t2mkM4lzjNBnQKdL80wuASZWCnAi50oUKBgwbHZdOsRKGV7C4zqAuTLTRaFpCQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
                 "tslib": "^2.3.0"
@@ -1133,6 +1207,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.47.2.tgz",
             "integrity": "sha512-ojAF5k/VFbPvJoj6/G6ekVQhbFvabUBvRhRaoQjkmj8LVEahtzcNcOxhu3FmH17mXR2oxWsGwvq6VAw6V3jLBg==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -1147,6 +1222,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.47.2.tgz",
             "integrity": "sha512-O35bXeahlepgPxg72XDN+5cXlbs+jZec5AH+7YYI+ldEVu6WxF0MxeQtMG4Fqpb19bpPIPz0SodHM1D1I53S5w==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/config-resolver": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -1163,6 +1239,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.47.1.tgz",
             "integrity": "sha512-9vBhp1E74s6nImK5xk7BkopQ10w6Vk8UrIinu71U7V/0PdjCEb4Jmnn++MLyim2jTT0QEGmJ6v0VjPZi9ETWaA==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1174,6 +1251,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.1.tgz",
             "integrity": "sha512-dMcBhtyJ7ZMNS8RS4UOVbkiR0gGrBWv+p1s9NLfMNXod9zaTAlMIKl9de8Xdshguvc8//J7heQV/7+HMvFEq2g==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1185,6 +1263,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.47.1.tgz",
             "integrity": "sha512-CGqm+bT07OCJSgDo48/4Fegh9tNPR3kcOMfNWZ/J6lrt+nfAnOdXx5zZB63PjKCt5zJ7LM0thOQgAeOf2WdJzQ==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1196,6 +1275,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.47.2.tgz",
             "integrity": "sha512-dstakqLW8hXRMzR/s3uLpfYbMs/qDowG/Fp123cAuln4rUODG29VNFLkMAYRnG6RQ9hf2OtXsCfFGNSm+bnJMg==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "bowser": "^2.11.0",
@@ -1206,6 +1286,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.47.2.tgz",
             "integrity": "sha512-9wYkGvTrOFWb+9QjziQma+l9M0u1tmHiIdL9r4Btsc9WVMsy1Y9HUUeXacM3dLLIzCpQ5dDbjIlAZWA8Rm3ZOQ==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -1219,6 +1300,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.47.1.tgz",
             "integrity": "sha512-PzHEdiBhfnZbHvZ+dIlIPodDbpgrpKDYslHe9A+tH8ZfuAxxmZEqnukp7QEkFr6mBcmq3H2thcPdNT45/5pA7Q==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             }
@@ -1227,6 +1309,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.47.2.tgz",
             "integrity": "sha512-itgWlytqhbD/pRiGxX7XY7RF8k15ScV816FUlZtOKeRpAphliFT07TGWKmiZcFxEbHpi9r8A5H1FOoPmyU635Q==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.47.2",
                 "tslib": "^2.3.0"
@@ -1239,6 +1322,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.47.2.tgz",
             "integrity": "sha512-3zzOEDPRgHJ3o17Ri0vVmCKvqh9tA2lP9WbpXTjOgEAfdI/hsP2XhqJWVrlyN+wQ6FwPbuX3Jsb7lsp1OZP2bg==",
+            "peer": true,
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -1252,6 +1336,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.47.1.tgz",
             "integrity": "sha512-SPDSKG7zw7MnGFVl3uIVNBBZo4WyNg8Wu82COfD8XaH+E/XiYiHjjoPq8eIscrQb799TXudHxy5h/C7dFACMxA==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -7120,7 +7205,8 @@
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "peer": true
         },
         "node_modules/boxen": {
             "version": "1.3.0",
@@ -11458,6 +11544,7 @@
             "version": "3.19.0",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
             "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+            "peer": true,
             "bin": {
                 "xml2js": "cli.js"
             },
@@ -32079,6 +32166,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
             "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+            "peer": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -32088,7 +32176,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "peer": true
                 }
             }
         },
@@ -32096,6 +32185,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
             "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+            "peer": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -32103,7 +32193,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "peer": true
                 }
             }
         },
@@ -32111,6 +32202,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "peer": true,
             "requires": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -32125,7 +32217,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "peer": true
                 }
             }
         },
@@ -32133,6 +32226,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "peer": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -32142,7 +32236,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "peer": true
                 }
             }
         },
@@ -32150,6 +32245,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
             "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+            "peer": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -32157,7 +32253,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "peer": true
                 }
             }
         },
@@ -32165,6 +32262,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
             "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "^3.1.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -32174,7 +32272,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "peer": true
                 }
             }
         },
@@ -32182,6 +32281,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.47.2.tgz",
             "integrity": "sha512-OpxsJ3b2KlpqTQKq6Py6JtLhA7KaAtHthH1JLLWStaFhU5/Js8nFnfPWdJIDRLpuAGyeRTbkjOEUsOkWAI5dAw==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32191,6 +32291,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.47.1.tgz",
             "integrity": "sha512-D8wcAumX+q/VlX6lbYHWJqsaDBvj1BHVjJlBwLPrUBcsk0bRaJhhbhesej6DkhRX2pFhwXlHgc7CAgYhJCtc/w==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32199,6 +32300,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.47.2.tgz",
             "integrity": "sha512-29+ZWESaFDQ9QXo7RGcUMuP89GTKo8bKlYplzNsO/B1uG17LgTgVHBapU3UBlF/EkOh1rzN5tEW+XwwstHvlXg==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/util-base64-browser": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32208,6 +32310,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.48.0.tgz",
             "integrity": "sha512-zOr7WWr9b5V3nTQnMTz+kjDpLJceI5Vmx3+mwi5a3vFDwJBvMJK0C25A9koDXtrjn8/hszAePh6+rC0oW8QJsQ==",
+            "peer": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -32264,6 +32367,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.48.0.tgz",
             "integrity": "sha512-A9f7B5k+X7bx062OQEcLHIMMIq0H1GlUqdw9xReCLd6W6vcRthbeSK5xbkM7TzHeKHE2/9qQYAy0lyKkxFE6bQ==",
+            "peer": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -32301,6 +32405,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.48.0.tgz",
             "integrity": "sha512-vOSIYCHjXB9nztZqwjIjV/jRZCfgej1YHpgqeNlfL8hPNhcrHemaoJaKHRPnhljIuHi+H5yQW7Pm4qJUFtGwKA==",
+            "peer": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -32343,6 +32448,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.47.2.tgz",
             "integrity": "sha512-uv9U/qDOSqyCPQ71qiwMslqRMxYyt0y0h6X0aQ67GCPq4rbbU/dn8PqnYT0VfX/9Ss+DcbTm7vOTxVKv+8XADA==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/signature-v4": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32354,6 +32460,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.47.2.tgz",
             "integrity": "sha512-HQKXY8y51kpTrD7P8fZJNf4MdCdu0+NcdOc+HScrQ21oZJv3BXUwXxKiOWY95Z3jYqyFwSKs1/FFuQ1mV0wjPg==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32364,6 +32471,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.47.2.tgz",
             "integrity": "sha512-7fCIofgU5pdKGgbCAYQ8H7sIFluN3oebFyFy7C4eXJyNy/8QKjFHEW3NkNCh0Bkd5sLOqkwYU3nyRx0CbNkEoQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.47.2",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -32376,6 +32484,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.48.0.tgz",
             "integrity": "sha512-PSTfzK8V+3WVJOv+wlS4y09KYZx3iYj4Ad8LMGmGE4aqew8eRf6u2WuTmqrWwuOTxDra9PJ1ObcM5vBc+nZcYA==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -32392,6 +32501,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.48.0.tgz",
             "integrity": "sha512-7CrbUT7yEZvYSQNXxZWN5KUx355wD+xrYIafoEST28T7nwcIiu7l2zpBY3JPhPIPNXqryVKfNQJvKV1dP3wF4g==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -32410,6 +32520,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.47.2.tgz",
             "integrity": "sha512-LBuABkVt/tdSoHy8hdGVnInZx5QADhK90dEHc41+HTTP3bCSNsSBIErkZnmhAD/3AGz7m/4qkPmhJOqzFisY/g==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
@@ -32422,6 +32533,7 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.48.0.tgz",
             "integrity": "sha512-31Ill3ZW35dueXb09PpOJ4C8oKdRGypbnycAgLYvvqYlO4LOs9FyQAsw+t2+ExvE6DznM0vkeWTQI3y7HUVYCA==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/client-sso": "3.48.0",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -32435,6 +32547,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.47.2.tgz",
             "integrity": "sha512-biJo8zJwNk8Dwrd/mkTcu8iLuOlGbsG2Uahta4StkOUhZ733xewOZ4WISLXVLocb/PXLM1lZQgkobwugpFOQRA==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32445,6 +32558,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.47.2.tgz",
             "integrity": "sha512-KRWpWBuICxIJOp5vPe2NzT387uW8Q5IpyMNf8SNmFe9a9yTrg2oIRKkbEHHRNyCRnjbDmpU3Td58V9bpmaBXGw==",
+            "peer": true,
             "requires": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-sdk/types": "3.47.1",
@@ -32456,6 +32570,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.47.2.tgz",
             "integrity": "sha512-dXjJ0eoNCu9P6uOzNcIL0OoXhVbdR/LPTRJCIR7NcfGCmJ4ZXeYwgYcHFTosrT/+SXAFGgsoU23dqA63TFWlMQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/eventstream-serde-universal": "3.47.2",
@@ -32467,6 +32582,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.47.2.tgz",
             "integrity": "sha512-LE481skmmWqoPhGyhFWqf/0eEtAFKSJqyzPZEer6yFUpejaijek4Heo6B+Y3cyDGoASuqY4Wum+9q1Z1xPn2BQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32476,6 +32592,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.47.2.tgz",
             "integrity": "sha512-hrEsbDFaRr7rNJw+qgua+YhkMgSkgR/YhBe+rdI20maaJARIjLo4C8eRqAqrmlE4i2+PU4CvM/fVdL9M3HQXfQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/eventstream-serde-universal": "3.47.2",
@@ -32487,6 +32604,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.47.2.tgz",
             "integrity": "sha512-Zkfa2kHKNsWSAdO4atr9+JPEtcZzWuJqZHMr8MO5aXAMnKd5BA9XvzyGyhrfpr9HmnoqcbXrcx8iqDxcFEIp5g==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32497,6 +32615,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.47.2.tgz",
             "integrity": "sha512-MZwwKtJwkWPm3Tzh+F3gcts13v1OuZih0slOO4GJpMxq46+lcW4DoW04lNHULJsyduXs4CziH8g65DDh0Yhq6w==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/querystring-builder": "3.47.2",
@@ -32509,6 +32628,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.47.2.tgz",
             "integrity": "sha512-DG8kGFUqXH+eQLLQtzTuBxBEuLHJ03w3X2Geq7aNvfwh06OOJW3FYz+FTLH2f2HxqlKOQtf3MsqpH074zKC5/A==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/chunked-blob-reader": "3.47.1",
                 "@aws-sdk/chunked-blob-reader-native": "3.47.2",
@@ -32520,6 +32640,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.47.2.tgz",
             "integrity": "sha512-OpUCNGvchKI1WoOCtCm36gQtECMz2P5mJoXxAHNZQ5qQ69A5Vk/DZs1V24N94M7tl1u7ZpbLsJbWFdu+P4B27g==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-buffer-from": "3.47.2",
@@ -32530,6 +32651,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.47.2.tgz",
             "integrity": "sha512-ModP4kZkkj4j1djuANwETAwYL1uTcXBHVcVLvy/wVDVLIcEW1TgGBgkY0rSGFE4RWDESTjhLCBKNDgvpxReSLQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32539,6 +32661,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.47.2.tgz",
             "integrity": "sha512-QLIp0Gv9IbSVXru1kS92M4kF9ZgHmVP7Us8dWSu5UC7LJt6Uxhxjb+e+F0h9qY1Z3Prior12I4r5COgVO3dWxA==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32548,6 +32671,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.47.1.tgz",
             "integrity": "sha512-HQMvT3dP6DCjmn87WkzYxUF9RqkvuXgKfddLEKj/tg/OgDQJv9xIPjEEry8Fd36ncbBqaBmC/z2ETZhpzHQvXA==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32556,6 +32680,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.47.2.tgz",
             "integrity": "sha512-APIz8mCPscYG6gCxvC2dbrBfpM3jHwAh+VqTmGHHxxO1AAP3y5ohtdl/2MsKtEPKuyT1IX2/YoUwcOyJj65xmw==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-utf8-browser": "3.47.1",
@@ -32567,6 +32692,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.47.2.tgz",
             "integrity": "sha512-sjZZZ7hOR9retsblYOs4cgsVg7r1Sfuvr/aIx16XXv3TeAk7fz8JTRf5STxMM6YkGIVMbvBOHpMNvcGGgJQhZQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -32578,6 +32704,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.47.2.tgz",
             "integrity": "sha512-VrUrkAUS3CqI7tK3r0c0oT+1SE1L+euyq6j6Jt3XOjRMUXCkArecVkr3jEprbpVDiAkaTXEJE77iL1+98twiYA==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32590,6 +32717,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.47.2.tgz",
             "integrity": "sha512-rpLtN6BczAfJnH1fpXyUOMdDFN3xrky3QZ4SULVgTLXNMOvN5zDJnjwUh/QNgEaEQhxd6lroVJSgosG3357kWg==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32600,6 +32728,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.47.2.tgz",
             "integrity": "sha512-sLv5q8+POzpMvp9dx/OInFr6VWJreHOGFoauYN1n7a+8dmhr9tycBLq/j+eBXI2FWwC3dXCBdrC9qs4ieSRe0Q==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/middleware-header-default": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -32611,6 +32740,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.47.2.tgz",
             "integrity": "sha512-fCcQaQ/ac+h8nS8d8nSrvP/scNTCdkHQ8PpNXo7nSz4a67xbxxln61T4iHOin8z0m62NlFrhtMdlQTtDqDEZVg==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32621,6 +32751,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.47.2.tgz",
             "integrity": "sha512-sDIGydvdO1LC7VQntTDMK+YYLRVCJAhrsCT8SxyAX0Jhu7Ek1BfRZzSZDwapL+idbMyyKsB80NpNoTWuKRrrew==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32631,6 +32762,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.47.2.tgz",
             "integrity": "sha512-b6ozPYnInQB1Iv+UjLyhunTCUcw54AKtUO7Mj2QLT2GqCPDPry7ZmAC9Qtfv4Itv7HyM4VfR1roAGKZwT4zxQw==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32640,6 +32772,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.47.2.tgz",
             "integrity": "sha512-Oz14cAaYmtzMYw0/ehlVLvMF4gqQS0qaYWGyyR4a3nONiwEDzxNMEQiEg7i8VgsP4usK7lfYZLXgwSmqo7uCzg==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32649,6 +32782,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.47.2.tgz",
             "integrity": "sha512-qgAE/+hVGXQDkqbVo+uFeb+N7mr7kBi0Oc1Fm490fm3uLQnXuyu3suIix//wxNejoLwIgKQGSLrQNgnXtuvhxw==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/service-error-classification": "3.47.2",
@@ -32660,7 +32794,8 @@
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+                    "peer": true
                 }
             }
         },
@@ -32668,6 +32803,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.47.2.tgz",
             "integrity": "sha512-KjcrHHDIn4QCh8pTRVT2u8uOnpdPYVB2p+xblwyRvJt2VLhgJbgNpRy8pOwNo2lyfbOKrmWeBk4x0NduiXle8g==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/signature-v4": "3.47.2",
@@ -32680,6 +32816,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.47.2.tgz",
             "integrity": "sha512-KlO4cYb4Bxf/Jg/uxlxRrFvxUR/DmjMIS+JRZNGqK4XyYA+apYZkfM0XUtMiKc491n/euluf9A0AyTxpMgixxg==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/middleware-signing": "3.47.2",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -32693,6 +32830,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.47.2.tgz",
             "integrity": "sha512-Gjw+fkG4UvvbP5LrGW1FzUq0IJB6QIBFxStE0gbyjkKNYtcb9c0R3dIwH5CSECtelDZScytwmBKaVe8NGi6wJA==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32702,6 +32840,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.47.2.tgz",
             "integrity": "sha512-r6/2gf5gwkVdI7EOa1TdYdfzOdCF3jkhjLi98c3nAxZNxZFGwoycIy7Bd6sCfOdcmk8NyVmR0APpsgD9q+a3nw==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -32714,6 +32853,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.47.2.tgz",
             "integrity": "sha512-dRNQJjvlg4omfhAfSYtZva4OpS/58aLO7y8l2o5sQHGPwob5OYO5zfPioi4h68UZw1fagG962hUywOkVJDJAuw==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32723,6 +32863,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.47.2.tgz",
             "integrity": "sha512-9wedI1L92stvg5fs6Y3CbUXYLZIYdI3Mrdqex+ulNRuepgZNORsk+dnb8rTkf9cO3nuWRrnfKBLc/uiTcA1dww==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32731,6 +32872,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.47.2.tgz",
             "integrity": "sha512-LF5gOi37lJ3tkuDSqZVKHmqYY8oTIUTEdmPVUbBQtPKsx9xfCNbMNVAP+C+7bnbt6StZIZsvtu0M144yNFXPGQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32741,6 +32883,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.47.2.tgz",
             "integrity": "sha512-POdigo6ZXLRVWhmjE21Y1Q1ziPnM/c3rH0wHgzAtdx0Mfn6/9jS77QHMkZzC8MJ7lzgXVFDWM25evVZqdYrh+g==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
@@ -32752,6 +32895,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.47.2.tgz",
             "integrity": "sha512-X2Y+H2DBoeDnrSe5rsVc63uhext230AuG/+hIFHK2/HkyG9DiiHKNCNj2w8N4FLWEX3l8KDif3C7BqYxj9ZkDg==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/abort-controller": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -32764,6 +32908,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.47.2.tgz",
             "integrity": "sha512-0NiVJ6+JtRC8XOvNb1ofHtsjINrinC1/fDKvl/bDtJDhehC5EcIeiDQmHFUhGsgTyD+VpmuHj7E4AlV6BchNPQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32773,6 +32918,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.47.2.tgz",
             "integrity": "sha512-XAQFbSigJD0fk61nSR6y6TMv3+o1IjymltWuDmGEtoI25pisC2M3A+3/xO9YHag/41CSgt9nQ+lh1iC4UlKKJw==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32782,6 +32928,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.47.2.tgz",
             "integrity": "sha512-rsckQ262jFSDVES6rOuTnSDM9XEbM57zxeBj5BtD6eCnyUD0G4FZa1xZRum4khoxfff6/eJ+i2uncKrEk1v+EQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-uri-escape": "3.47.1",
@@ -32792,6 +32939,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.47.2.tgz",
             "integrity": "sha512-28BirdFhZ+Y2pUMuI9r1ATgcQyt4q3cSqqpLSy7ADGb7xHde6oA/ZfRdX/s7OVIHoAfhrjAeI+TbYjwso9F/HA==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32800,12 +32948,14 @@
         "@aws-sdk/service-error-classification": {
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.47.2.tgz",
-            "integrity": "sha512-oJCJbAPYhTNguJUhD8hlD7ibWIDpkvGrhkcq89gxBcXHPl/2/kjsii0gr302IH452IJlumpVe5wOXoZeqZYjaw=="
+            "integrity": "sha512-oJCJbAPYhTNguJUhD8hlD7ibWIDpkvGrhkcq89gxBcXHPl/2/kjsii0gr302IH452IJlumpVe5wOXoZeqZYjaw==",
+            "peer": true
         },
         "@aws-sdk/shared-ini-file-loader": {
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.47.1.tgz",
             "integrity": "sha512-f0eVOMYkT4H0gOf1B9lw65/xeTa7rT9hocVB7DbjWk8Ifv46Uvlb4ZyYOLZIBDQyFNFrD/HHvja3BkzfV0MEOA==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32814,6 +32964,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.47.2.tgz",
             "integrity": "sha512-zJIhUY8LLiQldfM9wpgVw525dHbILJovyZm3xmm6Tq/t258cawNaeOvOp9w0I3ycA3gs+nKgMXdeMjLH8QLbWg==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "@aws-sdk/types": "3.47.1",
@@ -32841,6 +32992,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.47.2.tgz",
             "integrity": "sha512-vCzZodWyKmLzC+N/B1GzDjKD8I5b/ILTwPHaaH7yJdncISq/3jyTMJVW7mZHbDX61a18rL/bADnIxEd524Y2hQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/middleware-stack": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32850,12 +33002,14 @@
         "@aws-sdk/types": {
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.1.tgz",
-            "integrity": "sha512-c+lxJJLD5Bq8HkrgaIWQfK8oGH53CYpRRJizyQ5qfRo9aXp/qshUnIVcgnA8t0k7jfzcIfa0Q7jSSBw3EerEbg=="
+            "integrity": "sha512-c+lxJJLD5Bq8HkrgaIWQfK8oGH53CYpRRJizyQ5qfRo9aXp/qshUnIVcgnA8t0k7jfzcIfa0Q7jSSBw3EerEbg==",
+            "peer": true
         },
         "@aws-sdk/url-parser": {
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.47.2.tgz",
             "integrity": "sha512-xapm+8toLY1FJmdGWl/YWCGSbbzPitiKmcg9+NP1DIyZyHjzeG5vBZ2SYejYtGOf+Qn1VKyNN2+Qs049FOsh6w==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/querystring-parser": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32866,6 +33020,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.47.1.tgz",
             "integrity": "sha512-Q+tZjYyBeWMyPJ6+l42JXS7gt5crXywJbLDGjoLoS+Ba0JDB5zp8IMRLzGzQpTO+VnbL4ZyEEUVEihyqFbB0iw==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32874,6 +33029,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.47.1.tgz",
             "integrity": "sha512-asStae2d1xvgs3czWvvVb4JWHfY2iV8yximL4MwF+Lb8XG/b8LH3tG1E5axAFVMBcljdvRB941N7w3rug7V9ig==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32882,6 +33038,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.47.2.tgz",
             "integrity": "sha512-0Oml66+9/uERV1dosecA/1tEd0zdiwI3kEobCF5w2f4gJDzUdaEoztcRwtbLcFv6yVT7XoW4evMQbtlcruypcQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.47.2",
                 "tslib": "^2.3.0"
@@ -32891,6 +33048,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.47.1.tgz",
             "integrity": "sha512-qR307MATPC+4JtN7W9sSkchfdB3O4mulLKRpk7rF6Ns6vVwhaPfJstSGe9Qa68zYZXubF9h5WnoWuJz4N0Vqdw==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32899,6 +33057,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.47.1.tgz",
             "integrity": "sha512-U2K7+gi3bAQBb3WB1/trvA+4rPC2SKH9w/sRtqBwtxHNOjXjiCiF3oEYnbir7cdSfhzMH4HBYKbfkHZwTAHMfw==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32907,6 +33066,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.47.2.tgz",
             "integrity": "sha512-oLytLGiIeJEk7FcT7bdeQNv7+vvVVPuL5hyXlCjHZwoWuDxepjoDhTaIC9Isq1UyPKfSZaVpk/1nqREe4aYDHw==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32916,6 +33076,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.47.1.tgz",
             "integrity": "sha512-kBs+YghZaOqChxLZDTR8dw5RQxJ/qF064EjRpC+TdCegLCO2UtZ97RXBvc5mdt94OxXGjGUjDiD/eAlpjjFNXw==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32924,6 +33085,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.47.2.tgz",
             "integrity": "sha512-C0L8pfZkJyWfuvLVRcM2Ff11t2mkM4lzjNBnQKdL80wuASZWCnAi50oUKBgwbHZdOsRKGV7C4zqAuTLTRaFpCQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32933,6 +33095,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.47.2.tgz",
             "integrity": "sha512-ojAF5k/VFbPvJoj6/G6ekVQhbFvabUBvRhRaoQjkmj8LVEahtzcNcOxhu3FmH17mXR2oxWsGwvq6VAw6V3jLBg==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32944,6 +33107,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.47.2.tgz",
             "integrity": "sha512-O35bXeahlepgPxg72XDN+5cXlbs+jZec5AH+7YYI+ldEVu6WxF0MxeQtMG4Fqpb19bpPIPz0SodHM1D1I53S5w==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/config-resolver": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -32957,6 +33121,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.47.1.tgz",
             "integrity": "sha512-9vBhp1E74s6nImK5xk7BkopQ10w6Vk8UrIinu71U7V/0PdjCEb4Jmnn++MLyim2jTT0QEGmJ6v0VjPZi9ETWaA==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32965,6 +33130,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.1.tgz",
             "integrity": "sha512-dMcBhtyJ7ZMNS8RS4UOVbkiR0gGrBWv+p1s9NLfMNXod9zaTAlMIKl9de8Xdshguvc8//J7heQV/7+HMvFEq2g==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32973,6 +33139,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.47.1.tgz",
             "integrity": "sha512-CGqm+bT07OCJSgDo48/4Fegh9tNPR3kcOMfNWZ/J6lrt+nfAnOdXx5zZB63PjKCt5zJ7LM0thOQgAeOf2WdJzQ==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32981,6 +33148,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.47.2.tgz",
             "integrity": "sha512-dstakqLW8hXRMzR/s3uLpfYbMs/qDowG/Fp123cAuln4rUODG29VNFLkMAYRnG6RQ9hf2OtXsCfFGNSm+bnJMg==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "bowser": "^2.11.0",
@@ -32991,6 +33159,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.47.2.tgz",
             "integrity": "sha512-9wYkGvTrOFWb+9QjziQma+l9M0u1tmHiIdL9r4Btsc9WVMsy1Y9HUUeXacM3dLLIzCpQ5dDbjIlAZWA8Rm3ZOQ==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -33001,6 +33170,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.47.1.tgz",
             "integrity": "sha512-PzHEdiBhfnZbHvZ+dIlIPodDbpgrpKDYslHe9A+tH8ZfuAxxmZEqnukp7QEkFr6mBcmq3H2thcPdNT45/5pA7Q==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -33009,6 +33179,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.47.2.tgz",
             "integrity": "sha512-itgWlytqhbD/pRiGxX7XY7RF8k15ScV816FUlZtOKeRpAphliFT07TGWKmiZcFxEbHpi9r8A5H1FOoPmyU635Q==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.47.2",
                 "tslib": "^2.3.0"
@@ -33018,6 +33189,7 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.47.2.tgz",
             "integrity": "sha512-3zzOEDPRgHJ3o17Ri0vVmCKvqh9tA2lP9WbpXTjOgEAfdI/hsP2XhqJWVrlyN+wQ6FwPbuX3Jsb7lsp1OZP2bg==",
+            "peer": true,
             "requires": {
                 "@aws-sdk/abort-controller": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -33028,6 +33200,7 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.47.1.tgz",
             "integrity": "sha512-SPDSKG7zw7MnGFVl3uIVNBBZo4WyNg8Wu82COfD8XaH+E/XiYiHjjoPq8eIscrQb799TXudHxy5h/C7dFACMxA==",
+            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -37615,7 +37788,8 @@
         "bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "peer": true
         },
         "boxen": {
             "version": "1.3.0",
@@ -41062,7 +41236,8 @@
         "fast-xml-parser": {
             "version": "3.19.0",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-            "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+            "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+            "peer": true
         },
         "fastestsmallesttextencoderdecoder": {
             "version": "1.0.22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
             "name": "FCO-LOI-Service",
             "version": "0.0.1",
             "dependencies": {
+                "@aws-sdk/client-s3": "^3.48.0",
+                "@tokenizer/s3": "^0.2.0",
                 "amqplib": "^0.5.1",
                 "aws-sdk": "^2.940.0",
                 "axios": "^0.24.0",
@@ -120,6 +122,1141 @@
             },
             "engines": {
                 "node": "4.x"
+            }
+        },
+        "node_modules/@aws-crypto/crc32": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+            "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+            "dependencies": {
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/ie11-detection": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+            "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+            "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dependencies": {
+                "@aws-crypto/ie11-detection": "^2.0.0",
+                "@aws-crypto/sha256-js": "^2.0.0",
+                "@aws-crypto/supports-web-crypto": "^2.0.0",
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dependencies": {
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+            "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+            "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-sdk/abort-controller": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.47.2.tgz",
+            "integrity": "sha512-OpxsJ3b2KlpqTQKq6Py6JtLhA7KaAtHthH1JLLWStaFhU5/Js8nFnfPWdJIDRLpuAGyeRTbkjOEUsOkWAI5dAw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/chunked-blob-reader": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.47.1.tgz",
+            "integrity": "sha512-D8wcAumX+q/VlX6lbYHWJqsaDBvj1BHVjJlBwLPrUBcsk0bRaJhhbhesej6DkhRX2pFhwXlHgc7CAgYhJCtc/w==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/chunked-blob-reader-native": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.47.2.tgz",
+            "integrity": "sha512-29+ZWESaFDQ9QXo7RGcUMuP89GTKo8bKlYplzNsO/B1uG17LgTgVHBapU3UBlF/EkOh1rzN5tEW+XwwstHvlXg==",
+            "dependencies": {
+                "@aws-sdk/util-base64-browser": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.48.0.tgz",
+            "integrity": "sha512-zOr7WWr9b5V3nTQnMTz+kjDpLJceI5Vmx3+mwi5a3vFDwJBvMJK0C25A9koDXtrjn8/hszAePh6+rC0oW8QJsQ==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/client-sts": "3.48.0",
+                "@aws-sdk/config-resolver": "3.47.2",
+                "@aws-sdk/credential-provider-node": "3.48.0",
+                "@aws-sdk/eventstream-serde-browser": "3.47.2",
+                "@aws-sdk/eventstream-serde-config-resolver": "3.47.2",
+                "@aws-sdk/eventstream-serde-node": "3.47.2",
+                "@aws-sdk/fetch-http-handler": "3.47.2",
+                "@aws-sdk/hash-blob-browser": "3.47.2",
+                "@aws-sdk/hash-node": "3.47.2",
+                "@aws-sdk/hash-stream-node": "3.47.2",
+                "@aws-sdk/invalid-dependency": "3.47.2",
+                "@aws-sdk/md5-js": "3.47.2",
+                "@aws-sdk/middleware-apply-body-checksum": "3.47.2",
+                "@aws-sdk/middleware-bucket-endpoint": "3.47.2",
+                "@aws-sdk/middleware-content-length": "3.47.2",
+                "@aws-sdk/middleware-expect-continue": "3.47.2",
+                "@aws-sdk/middleware-host-header": "3.47.2",
+                "@aws-sdk/middleware-location-constraint": "3.47.2",
+                "@aws-sdk/middleware-logger": "3.47.2",
+                "@aws-sdk/middleware-retry": "3.47.2",
+                "@aws-sdk/middleware-sdk-s3": "3.47.2",
+                "@aws-sdk/middleware-serde": "3.47.2",
+                "@aws-sdk/middleware-signing": "3.47.2",
+                "@aws-sdk/middleware-ssec": "3.47.2",
+                "@aws-sdk/middleware-stack": "3.47.2",
+                "@aws-sdk/middleware-user-agent": "3.47.2",
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/node-http-handler": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/smithy-client": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/url-parser": "3.47.2",
+                "@aws-sdk/util-base64-browser": "3.47.1",
+                "@aws-sdk/util-base64-node": "3.47.2",
+                "@aws-sdk/util-body-length-browser": "3.47.1",
+                "@aws-sdk/util-body-length-node": "3.47.1",
+                "@aws-sdk/util-defaults-mode-browser": "3.47.2",
+                "@aws-sdk/util-defaults-mode-node": "3.47.2",
+                "@aws-sdk/util-user-agent-browser": "3.47.2",
+                "@aws-sdk/util-user-agent-node": "3.47.2",
+                "@aws-sdk/util-utf8-browser": "3.47.1",
+                "@aws-sdk/util-utf8-node": "3.47.2",
+                "@aws-sdk/util-waiter": "3.47.2",
+                "@aws-sdk/xml-builder": "3.47.1",
+                "entities": "2.2.0",
+                "fast-xml-parser": "3.19.0",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.48.0.tgz",
+            "integrity": "sha512-A9f7B5k+X7bx062OQEcLHIMMIq0H1GlUqdw9xReCLd6W6vcRthbeSK5xbkM7TzHeKHE2/9qQYAy0lyKkxFE6bQ==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.47.2",
+                "@aws-sdk/fetch-http-handler": "3.47.2",
+                "@aws-sdk/hash-node": "3.47.2",
+                "@aws-sdk/invalid-dependency": "3.47.2",
+                "@aws-sdk/middleware-content-length": "3.47.2",
+                "@aws-sdk/middleware-host-header": "3.47.2",
+                "@aws-sdk/middleware-logger": "3.47.2",
+                "@aws-sdk/middleware-retry": "3.47.2",
+                "@aws-sdk/middleware-serde": "3.47.2",
+                "@aws-sdk/middleware-stack": "3.47.2",
+                "@aws-sdk/middleware-user-agent": "3.47.2",
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/node-http-handler": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/smithy-client": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/url-parser": "3.47.2",
+                "@aws-sdk/util-base64-browser": "3.47.1",
+                "@aws-sdk/util-base64-node": "3.47.2",
+                "@aws-sdk/util-body-length-browser": "3.47.1",
+                "@aws-sdk/util-body-length-node": "3.47.1",
+                "@aws-sdk/util-defaults-mode-browser": "3.47.2",
+                "@aws-sdk/util-defaults-mode-node": "3.47.2",
+                "@aws-sdk/util-user-agent-browser": "3.47.2",
+                "@aws-sdk/util-user-agent-node": "3.47.2",
+                "@aws-sdk/util-utf8-browser": "3.47.1",
+                "@aws-sdk/util-utf8-node": "3.47.2",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.48.0.tgz",
+            "integrity": "sha512-vOSIYCHjXB9nztZqwjIjV/jRZCfgej1YHpgqeNlfL8hPNhcrHemaoJaKHRPnhljIuHi+H5yQW7Pm4qJUFtGwKA==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.47.2",
+                "@aws-sdk/credential-provider-node": "3.48.0",
+                "@aws-sdk/fetch-http-handler": "3.47.2",
+                "@aws-sdk/hash-node": "3.47.2",
+                "@aws-sdk/invalid-dependency": "3.47.2",
+                "@aws-sdk/middleware-content-length": "3.47.2",
+                "@aws-sdk/middleware-host-header": "3.47.2",
+                "@aws-sdk/middleware-logger": "3.47.2",
+                "@aws-sdk/middleware-retry": "3.47.2",
+                "@aws-sdk/middleware-sdk-sts": "3.47.2",
+                "@aws-sdk/middleware-serde": "3.47.2",
+                "@aws-sdk/middleware-signing": "3.47.2",
+                "@aws-sdk/middleware-stack": "3.47.2",
+                "@aws-sdk/middleware-user-agent": "3.47.2",
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/node-http-handler": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/smithy-client": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/url-parser": "3.47.2",
+                "@aws-sdk/util-base64-browser": "3.47.1",
+                "@aws-sdk/util-base64-node": "3.47.2",
+                "@aws-sdk/util-body-length-browser": "3.47.1",
+                "@aws-sdk/util-body-length-node": "3.47.1",
+                "@aws-sdk/util-defaults-mode-browser": "3.47.2",
+                "@aws-sdk/util-defaults-mode-node": "3.47.2",
+                "@aws-sdk/util-user-agent-browser": "3.47.2",
+                "@aws-sdk/util-user-agent-node": "3.47.2",
+                "@aws-sdk/util-utf8-browser": "3.47.1",
+                "@aws-sdk/util-utf8-node": "3.47.2",
+                "entities": "2.2.0",
+                "fast-xml-parser": "3.19.0",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/config-resolver": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.47.2.tgz",
+            "integrity": "sha512-uv9U/qDOSqyCPQ71qiwMslqRMxYyt0y0h6X0aQ67GCPq4rbbU/dn8PqnYT0VfX/9Ss+DcbTm7vOTxVKv+8XADA==",
+            "dependencies": {
+                "@aws-sdk/signature-v4": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-config-provider": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.47.2.tgz",
+            "integrity": "sha512-HQKXY8y51kpTrD7P8fZJNf4MdCdu0+NcdOc+HScrQ21oZJv3BXUwXxKiOWY95Z3jYqyFwSKs1/FFuQ1mV0wjPg==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-imds": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.47.2.tgz",
+            "integrity": "sha512-7fCIofgU5pdKGgbCAYQ8H7sIFluN3oebFyFy7C4eXJyNy/8QKjFHEW3NkNCh0Bkd5sLOqkwYU3nyRx0CbNkEoQ==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/url-parser": "3.47.2",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.48.0.tgz",
+            "integrity": "sha512-PSTfzK8V+3WVJOv+wlS4y09KYZx3iYj4Ad8LMGmGE4aqew8eRf6u2WuTmqrWwuOTxDra9PJ1ObcM5vBc+nZcYA==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.47.2",
+                "@aws-sdk/credential-provider-imds": "3.47.2",
+                "@aws-sdk/credential-provider-sso": "3.48.0",
+                "@aws-sdk/credential-provider-web-identity": "3.47.2",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-credentials": "3.47.2",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.48.0.tgz",
+            "integrity": "sha512-7CrbUT7yEZvYSQNXxZWN5KUx355wD+xrYIafoEST28T7nwcIiu7l2zpBY3JPhPIPNXqryVKfNQJvKV1dP3wF4g==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.47.2",
+                "@aws-sdk/credential-provider-imds": "3.47.2",
+                "@aws-sdk/credential-provider-ini": "3.48.0",
+                "@aws-sdk/credential-provider-process": "3.47.2",
+                "@aws-sdk/credential-provider-sso": "3.48.0",
+                "@aws-sdk/credential-provider-web-identity": "3.47.2",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-credentials": "3.47.2",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.47.2.tgz",
+            "integrity": "sha512-LBuABkVt/tdSoHy8hdGVnInZx5QADhK90dEHc41+HTTP3bCSNsSBIErkZnmhAD/3AGz7m/4qkPmhJOqzFisY/g==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-credentials": "3.47.2",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.48.0.tgz",
+            "integrity": "sha512-31Ill3ZW35dueXb09PpOJ4C8oKdRGypbnycAgLYvvqYlO4LOs9FyQAsw+t2+ExvE6DznM0vkeWTQI3y7HUVYCA==",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.48.0",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-credentials": "3.47.2",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.47.2.tgz",
+            "integrity": "sha512-biJo8zJwNk8Dwrd/mkTcu8iLuOlGbsG2Uahta4StkOUhZ733xewOZ4WISLXVLocb/PXLM1lZQgkobwugpFOQRA==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-marshaller": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.47.2.tgz",
+            "integrity": "sha512-KRWpWBuICxIJOp5vPe2NzT387uW8Q5IpyMNf8SNmFe9a9yTrg2oIRKkbEHHRNyCRnjbDmpU3Td58V9bpmaBXGw==",
+            "dependencies": {
+                "@aws-crypto/crc32": "2.0.0",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-hex-encoding": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-serde-browser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.47.2.tgz",
+            "integrity": "sha512-dXjJ0eoNCu9P6uOzNcIL0OoXhVbdR/LPTRJCIR7NcfGCmJ4ZXeYwgYcHFTosrT/+SXAFGgsoU23dqA63TFWlMQ==",
+            "dependencies": {
+                "@aws-sdk/eventstream-marshaller": "3.47.2",
+                "@aws-sdk/eventstream-serde-universal": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.47.2.tgz",
+            "integrity": "sha512-LE481skmmWqoPhGyhFWqf/0eEtAFKSJqyzPZEer6yFUpejaijek4Heo6B+Y3cyDGoASuqY4Wum+9q1Z1xPn2BQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-serde-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.47.2.tgz",
+            "integrity": "sha512-hrEsbDFaRr7rNJw+qgua+YhkMgSkgR/YhBe+rdI20maaJARIjLo4C8eRqAqrmlE4i2+PU4CvM/fVdL9M3HQXfQ==",
+            "dependencies": {
+                "@aws-sdk/eventstream-marshaller": "3.47.2",
+                "@aws-sdk/eventstream-serde-universal": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-serde-universal": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.47.2.tgz",
+            "integrity": "sha512-Zkfa2kHKNsWSAdO4atr9+JPEtcZzWuJqZHMr8MO5aXAMnKd5BA9XvzyGyhrfpr9HmnoqcbXrcx8iqDxcFEIp5g==",
+            "dependencies": {
+                "@aws-sdk/eventstream-marshaller": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/fetch-http-handler": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.47.2.tgz",
+            "integrity": "sha512-MZwwKtJwkWPm3Tzh+F3gcts13v1OuZih0slOO4GJpMxq46+lcW4DoW04lNHULJsyduXs4CziH8g65DDh0Yhq6w==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/querystring-builder": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-base64-browser": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/hash-blob-browser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.47.2.tgz",
+            "integrity": "sha512-DG8kGFUqXH+eQLLQtzTuBxBEuLHJ03w3X2Geq7aNvfwh06OOJW3FYz+FTLH2f2HxqlKOQtf3MsqpH074zKC5/A==",
+            "dependencies": {
+                "@aws-sdk/chunked-blob-reader": "3.47.1",
+                "@aws-sdk/chunked-blob-reader-native": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/hash-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.47.2.tgz",
+            "integrity": "sha512-OpUCNGvchKI1WoOCtCm36gQtECMz2P5mJoXxAHNZQ5qQ69A5Vk/DZs1V24N94M7tl1u7ZpbLsJbWFdu+P4B27g==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-buffer-from": "3.47.2",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/hash-stream-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.47.2.tgz",
+            "integrity": "sha512-ModP4kZkkj4j1djuANwETAwYL1uTcXBHVcVLvy/wVDVLIcEW1TgGBgkY0rSGFE4RWDESTjhLCBKNDgvpxReSLQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/invalid-dependency": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.47.2.tgz",
+            "integrity": "sha512-QLIp0Gv9IbSVXru1kS92M4kF9ZgHmVP7Us8dWSu5UC7LJt6Uxhxjb+e+F0h9qY1Z3Prior12I4r5COgVO3dWxA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/is-array-buffer": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.47.1.tgz",
+            "integrity": "sha512-HQMvT3dP6DCjmn87WkzYxUF9RqkvuXgKfddLEKj/tg/OgDQJv9xIPjEEry8Fd36ncbBqaBmC/z2ETZhpzHQvXA==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/md5-js": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.47.2.tgz",
+            "integrity": "sha512-APIz8mCPscYG6gCxvC2dbrBfpM3jHwAh+VqTmGHHxxO1AAP3y5ohtdl/2MsKtEPKuyT1IX2/YoUwcOyJj65xmw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-utf8-browser": "3.47.1",
+                "@aws-sdk/util-utf8-node": "3.47.2",
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-apply-body-checksum": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.47.2.tgz",
+            "integrity": "sha512-sjZZZ7hOR9retsblYOs4cgsVg7r1Sfuvr/aIx16XXv3TeAk7fz8JTRf5STxMM6YkGIVMbvBOHpMNvcGGgJQhZQ==",
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.47.1",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.47.2.tgz",
+            "integrity": "sha512-VrUrkAUS3CqI7tK3r0c0oT+1SE1L+euyq6j6Jt3XOjRMUXCkArecVkr3jEprbpVDiAkaTXEJE77iL1+98twiYA==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-arn-parser": "3.47.1",
+                "@aws-sdk/util-config-provider": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-content-length": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.47.2.tgz",
+            "integrity": "sha512-rpLtN6BczAfJnH1fpXyUOMdDFN3xrky3QZ4SULVgTLXNMOvN5zDJnjwUh/QNgEaEQhxd6lroVJSgosG3357kWg==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-expect-continue": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.47.2.tgz",
+            "integrity": "sha512-sLv5q8+POzpMvp9dx/OInFr6VWJreHOGFoauYN1n7a+8dmhr9tycBLq/j+eBXI2FWwC3dXCBdrC9qs4ieSRe0Q==",
+            "dependencies": {
+                "@aws-sdk/middleware-header-default": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-header-default": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.47.2.tgz",
+            "integrity": "sha512-fCcQaQ/ac+h8nS8d8nSrvP/scNTCdkHQ8PpNXo7nSz4a67xbxxln61T4iHOin8z0m62NlFrhtMdlQTtDqDEZVg==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.47.2.tgz",
+            "integrity": "sha512-sDIGydvdO1LC7VQntTDMK+YYLRVCJAhrsCT8SxyAX0Jhu7Ek1BfRZzSZDwapL+idbMyyKsB80NpNoTWuKRrrew==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-location-constraint": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.47.2.tgz",
+            "integrity": "sha512-b6ozPYnInQB1Iv+UjLyhunTCUcw54AKtUO7Mj2QLT2GqCPDPry7ZmAC9Qtfv4Itv7HyM4VfR1roAGKZwT4zxQw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.47.2.tgz",
+            "integrity": "sha512-Oz14cAaYmtzMYw0/ehlVLvMF4gqQS0qaYWGyyR4a3nONiwEDzxNMEQiEg7i8VgsP4usK7lfYZLXgwSmqo7uCzg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-retry": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.47.2.tgz",
+            "integrity": "sha512-qgAE/+hVGXQDkqbVo+uFeb+N7mr7kBi0Oc1Fm490fm3uLQnXuyu3suIix//wxNejoLwIgKQGSLrQNgnXtuvhxw==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/service-error-classification": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.47.2.tgz",
+            "integrity": "sha512-KjcrHHDIn4QCh8pTRVT2u8uOnpdPYVB2p+xblwyRvJt2VLhgJbgNpRy8pOwNo2lyfbOKrmWeBk4x0NduiXle8g==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/signature-v4": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-arn-parser": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/signature-v4-crt": "^3.31.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-sts": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.47.2.tgz",
+            "integrity": "sha512-KlO4cYb4Bxf/Jg/uxlxRrFvxUR/DmjMIS+JRZNGqK4XyYA+apYZkfM0XUtMiKc491n/euluf9A0AyTxpMgixxg==",
+            "dependencies": {
+                "@aws-sdk/middleware-signing": "3.47.2",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/signature-v4": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-serde": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.47.2.tgz",
+            "integrity": "sha512-Gjw+fkG4UvvbP5LrGW1FzUq0IJB6QIBFxStE0gbyjkKNYtcb9c0R3dIwH5CSECtelDZScytwmBKaVe8NGi6wJA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.47.2.tgz",
+            "integrity": "sha512-r6/2gf5gwkVdI7EOa1TdYdfzOdCF3jkhjLi98c3nAxZNxZFGwoycIy7Bd6sCfOdcmk8NyVmR0APpsgD9q+a3nw==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/signature-v4": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-ssec": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.47.2.tgz",
+            "integrity": "sha512-dRNQJjvlg4omfhAfSYtZva4OpS/58aLO7y8l2o5sQHGPwob5OYO5zfPioi4h68UZw1fagG962hUywOkVJDJAuw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-stack": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.47.2.tgz",
+            "integrity": "sha512-9wedI1L92stvg5fs6Y3CbUXYLZIYdI3Mrdqex+ulNRuepgZNORsk+dnb8rTkf9cO3nuWRrnfKBLc/uiTcA1dww==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.47.2.tgz",
+            "integrity": "sha512-LF5gOi37lJ3tkuDSqZVKHmqYY8oTIUTEdmPVUbBQtPKsx9xfCNbMNVAP+C+7bnbt6StZIZsvtu0M144yNFXPGQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-config-provider": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.47.2.tgz",
+            "integrity": "sha512-POdigo6ZXLRVWhmjE21Y1Q1ziPnM/c3rH0wHgzAtdx0Mfn6/9jS77QHMkZzC8MJ7lzgXVFDWM25evVZqdYrh+g==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-http-handler": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.47.2.tgz",
+            "integrity": "sha512-X2Y+H2DBoeDnrSe5rsVc63uhext230AuG/+hIFHK2/HkyG9DiiHKNCNj2w8N4FLWEX3l8KDif3C7BqYxj9ZkDg==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/querystring-builder": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/property-provider": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.47.2.tgz",
+            "integrity": "sha512-0NiVJ6+JtRC8XOvNb1ofHtsjINrinC1/fDKvl/bDtJDhehC5EcIeiDQmHFUhGsgTyD+VpmuHj7E4AlV6BchNPQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/protocol-http": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.47.2.tgz",
+            "integrity": "sha512-XAQFbSigJD0fk61nSR6y6TMv3+o1IjymltWuDmGEtoI25pisC2M3A+3/xO9YHag/41CSgt9nQ+lh1iC4UlKKJw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-builder": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.47.2.tgz",
+            "integrity": "sha512-rsckQ262jFSDVES6rOuTnSDM9XEbM57zxeBj5BtD6eCnyUD0G4FZa1xZRum4khoxfff6/eJ+i2uncKrEk1v+EQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-uri-escape": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-parser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.47.2.tgz",
+            "integrity": "sha512-28BirdFhZ+Y2pUMuI9r1ATgcQyt4q3cSqqpLSy7ADGb7xHde6oA/ZfRdX/s7OVIHoAfhrjAeI+TbYjwso9F/HA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/service-error-classification": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.47.2.tgz",
+            "integrity": "sha512-oJCJbAPYhTNguJUhD8hlD7ibWIDpkvGrhkcq89gxBcXHPl/2/kjsii0gr302IH452IJlumpVe5wOXoZeqZYjaw==",
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/shared-ini-file-loader": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.47.1.tgz",
+            "integrity": "sha512-f0eVOMYkT4H0gOf1B9lw65/xeTa7rT9hocVB7DbjWk8Ifv46Uvlb4ZyYOLZIBDQyFNFrD/HHvja3BkzfV0MEOA==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.47.2.tgz",
+            "integrity": "sha512-zJIhUY8LLiQldfM9wpgVw525dHbILJovyZm3xmm6Tq/t258cawNaeOvOp9w0I3ycA3gs+nKgMXdeMjLH8QLbWg==",
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-hex-encoding": "3.47.1",
+                "@aws-sdk/util-uri-escape": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4-crt": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.47.2.tgz",
+            "integrity": "sha512-ImDwJ9UFvssEK5xIBzsQPWnvPL/BXLrYQQnSwv258/wJeAtGTJefz2quqkDax11IkphZMg8ieeSZ7k0CJh5Ktg==",
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.47.1",
+                "@aws-sdk/querystring-parser": "3.47.2",
+                "@aws-sdk/signature-v4": "3.47.2",
+                "@aws-sdk/util-hex-encoding": "3.47.1",
+                "@aws-sdk/util-uri-escape": "3.47.1",
+                "aws-crt": "^1.9.7",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/smithy-client": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.47.2.tgz",
+            "integrity": "sha512-vCzZodWyKmLzC+N/B1GzDjKD8I5b/ILTwPHaaH7yJdncISq/3jyTMJVW7mZHbDX61a18rL/bADnIxEd524Y2hQ==",
+            "dependencies": {
+                "@aws-sdk/middleware-stack": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.1.tgz",
+            "integrity": "sha512-c+lxJJLD5Bq8HkrgaIWQfK8oGH53CYpRRJizyQ5qfRo9aXp/qshUnIVcgnA8t0k7jfzcIfa0Q7jSSBw3EerEbg==",
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/url-parser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.47.2.tgz",
+            "integrity": "sha512-xapm+8toLY1FJmdGWl/YWCGSbbzPitiKmcg9+NP1DIyZyHjzeG5vBZ2SYejYtGOf+Qn1VKyNN2+Qs049FOsh6w==",
+            "dependencies": {
+                "@aws-sdk/querystring-parser": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-arn-parser": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.47.1.tgz",
+            "integrity": "sha512-Q+tZjYyBeWMyPJ6+l42JXS7gt5crXywJbLDGjoLoS+Ba0JDB5zp8IMRLzGzQpTO+VnbL4ZyEEUVEihyqFbB0iw==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-base64-browser": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.47.1.tgz",
+            "integrity": "sha512-asStae2d1xvgs3czWvvVb4JWHfY2iV8yximL4MwF+Lb8XG/b8LH3tG1E5axAFVMBcljdvRB941N7w3rug7V9ig==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-base64-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.47.2.tgz",
+            "integrity": "sha512-0Oml66+9/uERV1dosecA/1tEd0zdiwI3kEobCF5w2f4gJDzUdaEoztcRwtbLcFv6yVT7XoW4evMQbtlcruypcQ==",
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.47.2",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-browser": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.47.1.tgz",
+            "integrity": "sha512-qR307MATPC+4JtN7W9sSkchfdB3O4mulLKRpk7rF6Ns6vVwhaPfJstSGe9Qa68zYZXubF9h5WnoWuJz4N0Vqdw==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-node": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.47.1.tgz",
+            "integrity": "sha512-U2K7+gi3bAQBb3WB1/trvA+4rPC2SKH9w/sRtqBwtxHNOjXjiCiF3oEYnbir7cdSfhzMH4HBYKbfkHZwTAHMfw==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-buffer-from": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.47.2.tgz",
+            "integrity": "sha512-oLytLGiIeJEk7FcT7bdeQNv7+vvVVPuL5hyXlCjHZwoWuDxepjoDhTaIC9Isq1UyPKfSZaVpk/1nqREe4aYDHw==",
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-config-provider": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.47.1.tgz",
+            "integrity": "sha512-kBs+YghZaOqChxLZDTR8dw5RQxJ/qF064EjRpC+TdCegLCO2UtZ97RXBvc5mdt94OxXGjGUjDiD/eAlpjjFNXw==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-credentials": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.47.2.tgz",
+            "integrity": "sha512-C0L8pfZkJyWfuvLVRcM2Ff11t2mkM4lzjNBnQKdL80wuASZWCnAi50oUKBgwbHZdOsRKGV7C4zqAuTLTRaFpCQ==",
+            "dependencies": {
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-browser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.47.2.tgz",
+            "integrity": "sha512-ojAF5k/VFbPvJoj6/G6ekVQhbFvabUBvRhRaoQjkmj8LVEahtzcNcOxhu3FmH17mXR2oxWsGwvq6VAw6V3jLBg==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.47.2.tgz",
+            "integrity": "sha512-O35bXeahlepgPxg72XDN+5cXlbs+jZec5AH+7YYI+ldEVu6WxF0MxeQtMG4Fqpb19bpPIPz0SodHM1D1I53S5w==",
+            "dependencies": {
+                "@aws-sdk/config-resolver": "3.47.2",
+                "@aws-sdk/credential-provider-imds": "3.47.2",
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-hex-encoding": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.47.1.tgz",
+            "integrity": "sha512-9vBhp1E74s6nImK5xk7BkopQ10w6Vk8UrIinu71U7V/0PdjCEb4Jmnn++MLyim2jTT0QEGmJ6v0VjPZi9ETWaA==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.1.tgz",
+            "integrity": "sha512-dMcBhtyJ7ZMNS8RS4UOVbkiR0gGrBWv+p1s9NLfMNXod9zaTAlMIKl9de8Xdshguvc8//J7heQV/7+HMvFEq2g==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-uri-escape": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.47.1.tgz",
+            "integrity": "sha512-CGqm+bT07OCJSgDo48/4Fegh9tNPR3kcOMfNWZ/J6lrt+nfAnOdXx5zZB63PjKCt5zJ7LM0thOQgAeOf2WdJzQ==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.47.2.tgz",
+            "integrity": "sha512-dstakqLW8hXRMzR/s3uLpfYbMs/qDowG/Fp123cAuln4rUODG29VNFLkMAYRnG6RQ9hf2OtXsCfFGNSm+bnJMg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.47.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.47.2.tgz",
+            "integrity": "sha512-9wYkGvTrOFWb+9QjziQma+l9M0u1tmHiIdL9r4Btsc9WVMsy1Y9HUUeXacM3dLLIzCpQ5dDbjIlAZWA8Rm3ZOQ==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8-browser": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.47.1.tgz",
+            "integrity": "sha512-PzHEdiBhfnZbHvZ+dIlIPodDbpgrpKDYslHe9A+tH8ZfuAxxmZEqnukp7QEkFr6mBcmq3H2thcPdNT45/5pA7Q==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.47.2.tgz",
+            "integrity": "sha512-itgWlytqhbD/pRiGxX7XY7RF8k15ScV816FUlZtOKeRpAphliFT07TGWKmiZcFxEbHpi9r8A5H1FOoPmyU635Q==",
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.47.2",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-waiter": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.47.2.tgz",
+            "integrity": "sha512-3zzOEDPRgHJ3o17Ri0vVmCKvqh9tA2lP9WbpXTjOgEAfdI/hsP2XhqJWVrlyN+wQ6FwPbuX3Jsb7lsp1OZP2bg==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.47.1.tgz",
+            "integrity": "sha512-SPDSKG7zw7MnGFVl3uIVNBBZo4WyNg8Wu82COfD8XaH+E/XiYiHjjoPq8eIscrQb799TXudHxy5h/C7dFACMxA==",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1506,6 +2643,46 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
+        },
+        "node_modules/@httptoolkit/websocket-stream": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.0.tgz",
+            "integrity": "sha512-EC8m9JbhpGX2okfvLakqrmy4Le0VyNKR7b3IdvFZR/BfFO4ruh/XceBvXhCFHkykchnFxuOSlRwFiqNSXlwcGA==",
+            "peer": true,
+            "dependencies": {
+                "@types/ws": "*",
+                "duplexify": "^3.5.1",
+                "inherits": "^2.0.1",
+                "isomorphic-ws": "^4.0.1",
+                "readable-stream": "^2.3.3",
+                "safe-buffer": "^5.1.2",
+                "ws": "*",
+                "xtend": "^4.0.0"
+            }
+        },
+        "node_modules/@httptoolkit/websocket-stream/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "peer": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/@httptoolkit/websocket-stream/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "peer": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -4127,6 +5304,89 @@
                 "@testing-library/dom": ">=7.21.4"
             }
         },
+        "node_modules/@tokenizer/range": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@tokenizer/range/-/range-0.4.1.tgz",
+            "integrity": "sha512-GOfl0wtGJIIg1OqxOO3P2BAZqDhuxMDviIAi7dy3nHC629css5Rk77LXL6ljyY6yRI+KWBYlJOcb0lPj99tbZQ==",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "strtok3": "^6.0.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/@tokenizer/range/node_modules/debug": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@tokenizer/range/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/@tokenizer/s3": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/s3/-/s3-0.2.0.tgz",
+            "integrity": "sha512-v6KDDP6SsYydNAAt7AVkOocjDKCTp3puuCA0UVPR/eFLU+NYwOkfIWhRjdXMG9LzItoDK+kn7ACawJmAHM+F9w==",
+            "dependencies": {
+                "@tokenizer/range": "^0.4.0",
+                "strtok3": "6.1.3"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-s3": "^3.22.0"
+            }
+        },
+        "node_modules/@tokenizer/s3/node_modules/@tokenizer/token": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
+            "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+        },
+        "node_modules/@tokenizer/s3/node_modules/peek-readable": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.4.tgz",
+            "integrity": "sha512-DX7ec7frSMtCWw+zMd27f66hcxIz/w9LQTY2RflB4WNHCVPAye1pJiP2t3gvaaOhu7IOhtPbHw8MemMj+F5lrg==",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/@tokenizer/s3/node_modules/strtok3": {
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.1.3.tgz",
+            "integrity": "sha512-ssWSKFOeUTurMSucgyUf+a6Z9mVTYrsYiyEK5RLnh8BM6sFrKSljVlnjZXIDxMguYfdQI+mUPFHo88FYTxq1XA==",
+            "dependencies": {
+                "@tokenizer/token": "^0.1.1",
+                "peek-readable": "^3.1.4"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
         "node_modules/@tokenizer/token": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -4239,8 +5499,7 @@
         "node_modules/@types/node": {
             "version": "15.12.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-            "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
-            "dev": true
+            "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww=="
         },
         "node_modules/@types/prettier": {
             "version": "2.3.0",
@@ -4273,6 +5532,15 @@
             "dev": true,
             "dependencies": {
                 "@types/jest": "*"
+            }
+        },
+        "node_modules/@types/ws": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
+            "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@types/yargs": {
@@ -4766,6 +6034,12 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/ansi": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+            "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+            "peer": true
+        },
         "node_modules/ansi-align": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -5122,6 +6396,70 @@
             "engines": {
                 "node": ">= 4.5.0"
             }
+        },
+        "node_modules/aws-crt": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.10.6.tgz",
+            "integrity": "sha512-LCOFwFdUk3NJNUkm0YuiqU2jPtnC5OZYeLqIZyqVzDoSpK2wL7QAaA553v4YPA5xs3QU7jCmaDl6y3LjJTm4+w==",
+            "hasInstallScript": true,
+            "peer": true,
+            "dependencies": {
+                "@httptoolkit/websocket-stream": "^6.0.0",
+                "axios": "^0.24.0",
+                "cmake-js": "6.3.0",
+                "crypto-js": "^4.0.0",
+                "fastestsmallesttextencoderdecoder": "^1.0.22",
+                "mqtt": "^4.3.4",
+                "tar": "^6.1.11",
+                "ws": "^7.5.5"
+            }
+        },
+        "node_modules/aws-crt/node_modules/minipass": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+            "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+            "peer": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/aws-crt/node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "peer": true,
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/aws-crt/node_modules/tar": {
+            "version": "6.1.11",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+            "peer": true,
+            "dependencies": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^3.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/aws-crt/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "peer": true
         },
         "node_modules/aws-sdk": {
             "version": "2.940.0",
@@ -5575,6 +6913,28 @@
                 "node": "*"
             }
         },
+        "node_modules/big-integer": {
+            "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+            "peer": true,
+            "dependencies": {
+                "buffers": "~0.1.1",
+                "chainsaw": "~0.1.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/binary-extensions": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -5608,6 +6968,84 @@
             },
             "engines": {
                 "node": ">=0.8"
+            }
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "peer": true,
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bl/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "peer": true,
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/bl/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "peer": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/bl/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "peer": true
+        },
+        "node_modules/bl/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "peer": true,
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/blob-util": {
@@ -5678,6 +7116,11 @@
             "engines": {
                 "node": ">=0.10.40"
             }
+        },
+        "node_modules/bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "node_modules/boxen": {
             "version": "1.3.0",
@@ -5825,6 +7268,15 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
         },
+        "node_modules/buffer-indexof-polyfill": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
         "node_modules/buffer-more-ints": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
@@ -5841,6 +7293,15 @@
             "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+            "peer": true,
+            "engines": {
+                "node": ">=0.2.0"
             }
         },
         "node_modules/busboy": {
@@ -6071,6 +7532,18 @@
                 "node": ">=4"
             }
         },
+        "node_modules/chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+            "peer": true,
+            "dependencies": {
+                "traverse": ">=0.3.0 <0.4"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -6226,6 +7699,15 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/ci-info": {
@@ -6521,6 +8003,320 @@
                 "node": ">=6"
             }
         },
+        "node_modules/cmake-js": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.0.tgz",
+            "integrity": "sha512-1uqTOmFt6BIqKlrX+39/aewU/JVhyZWDqwAL+6psToUwxj3yWPJiwxiZFmV0XdcoWmqGs7peZTxTbJtAcH8hxw==",
+            "peer": true,
+            "dependencies": {
+                "axios": "^0.21.1",
+                "debug": "^4",
+                "fs-extra": "^5.0.0",
+                "is-iojs": "^1.0.1",
+                "lodash": "^4",
+                "memory-stream": "0",
+                "npmlog": "^1.2.0",
+                "rc": "^1.2.7",
+                "semver": "^5.0.3",
+                "splitargs": "0",
+                "tar": "^4",
+                "unzipper": "^0.8.13",
+                "url-join": "0",
+                "which": "^1.0.9",
+                "yargs": "^3.6.0"
+            },
+            "bin": {
+                "cmake-js": "bin/cmake-js"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/are-we-there-yet": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+            "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
+            "peer": true,
+            "dependencies": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.0 || ^1.1.13"
+            }
+        },
+        "node_modules/cmake-js/node_modules/axios": {
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "peer": true,
+            "dependencies": {
+                "follow-redirects": "^1.14.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/camelcase": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "peer": true
+        },
+        "node_modules/cmake-js/node_modules/cliui": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "peer": true,
+            "dependencies": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/debug": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "peer": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/cmake-js/node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "peer": true,
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/fs-extra": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+            "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+            "peer": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/fs-minipass": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+            "peer": true,
+            "dependencies": {
+                "minipass": "^2.6.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/gauge": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+            "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+            "peer": true,
+            "dependencies": {
+                "ansi": "^0.3.0",
+                "has-unicode": "^2.0.0",
+                "lodash.pad": "^4.1.0",
+                "lodash.padend": "^4.1.0",
+                "lodash.padstart": "^4.1.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "peer": true,
+            "dependencies": {
+                "number-is-nan": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "peer": true,
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/cmake-js/node_modules/minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "peer": true
+        },
+        "node_modules/cmake-js/node_modules/minizlib": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+            "peer": true,
+            "dependencies": {
+                "minipass": "^2.9.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "peer": true
+        },
+        "node_modules/cmake-js/node_modules/npmlog": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+            "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+            "peer": true,
+            "dependencies": {
+                "ansi": "~0.3.0",
+                "are-we-there-yet": "~1.0.0",
+                "gauge": "~1.2.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "peer": true,
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/cmake-js/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "peer": true
+        },
+        "node_modules/cmake-js/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "peer": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/cmake-js/node_modules/string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "peer": true,
+            "dependencies": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/tar": {
+            "version": "4.4.19",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+            "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+            "peer": true,
+            "dependencies": {
+                "chownr": "^1.1.4",
+                "fs-minipass": "^1.2.7",
+                "minipass": "^2.9.0",
+                "minizlib": "^1.3.3",
+                "mkdirp": "^0.5.5",
+                "safe-buffer": "^5.2.1",
+                "yallist": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=4.5"
+            }
+        },
+        "node_modules/cmake-js/node_modules/window-size": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+            "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+            "peer": true,
+            "bin": {
+                "window-size": "cli.js"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "peer": true,
+            "dependencies": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/cmake-js/node_modules/y18n": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+            "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+            "peer": true
+        },
+        "node_modules/cmake-js/node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "peer": true
+        },
+        "node_modules/cmake-js/node_modules/yargs": {
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+            "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+            "peer": true,
+            "dependencies": {
+                "camelcase": "^2.0.1",
+                "cliui": "^3.0.3",
+                "decamelize": "^1.1.1",
+                "os-locale": "^1.4.0",
+                "string-width": "^1.0.1",
+                "window-size": "^0.1.4",
+                "y18n": "^3.2.0"
+            }
+        },
         "node_modules/co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6620,6 +8416,31 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "node_modules/commist": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+            "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
+            "peer": true,
+            "dependencies": {
+                "leven": "^2.1.0",
+                "minimist": "^1.1.0"
+            }
+        },
+        "node_modules/commist/node_modules/leven": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+            "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/commist/node_modules/minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "peer": true
         },
         "node_modules/common-tags": {
             "version": "1.8.0",
@@ -7185,6 +9006,12 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/crypto-js": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+            "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
+            "peer": true
         },
         "node_modules/crypto-random-string": {
             "version": "1.0.0",
@@ -8505,6 +10332,39 @@
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
         },
+        "node_modules/duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "peer": true,
+            "dependencies": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "node_modules/duplexer2/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "peer": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/duplexer2/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "peer": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
         "node_modules/duplexer3": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -8713,7 +10573,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-            "dev": true,
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
@@ -9595,6 +11454,24 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
+        "node_modules/fast-xml-parser": {
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+            "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+            "bin": {
+                "xml2js": "cli.js"
+            },
+            "funding": {
+                "type": "paypal",
+                "url": "https://paypal.me/naturalintelligence"
+            }
+        },
+        "node_modules/fastestsmallesttextencoderdecoder": {
+            "version": "1.0.22",
+            "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+            "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+            "peer": true
+        },
         "node_modules/faye-websocket": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -9973,6 +11850,36 @@
                 "path-is-absolute": "^1.0.0",
                 "rimraf": "^2.2.8"
             }
+        },
+        "node_modules/fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "peer": true,
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/fs-minipass/node_modules/minipass": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+            "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+            "peer": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/fs-minipass/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "peer": true
         },
         "node_modules/fs-promise": {
             "version": "2.0.3",
@@ -11901,6 +13808,59 @@
                 "he": "bin/he"
             }
         },
+        "node_modules/help-me": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+            "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
+            "peer": true,
+            "dependencies": {
+                "glob": "^7.1.6",
+                "readable-stream": "^3.6.0"
+            }
+        },
+        "node_modules/help-me/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "peer": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/help-me/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "peer": true
+        },
+        "node_modules/help-me/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "peer": true,
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
         "node_modules/hoek": {
             "version": "2.16.3",
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -12495,6 +14455,15 @@
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
             "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls="
         },
+        "node_modules/invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -12813,6 +14782,12 @@
                 "node": ">=4"
             }
         },
+        "node_modules/is-iojs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
+            "integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
+            "peer": true
+        },
         "node_modules/is-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
@@ -13096,6 +15071,15 @@
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isomorphic-ws": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+            "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+            "peer": true,
+            "peerDependencies": {
+                "ws": "*"
             }
         },
         "node_modules/isstream": {
@@ -17640,6 +19624,12 @@
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.3.tgz",
             "integrity": "sha512-fiUvdfCaAXoQTHdKMgTvg6IkecXDcVz6V5rlftUTclF9IKBjMizvSdQaCl/z/6TApDeby5NL+axYou3i0mu1Pg=="
         },
+        "node_modules/js-sdsl": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+            "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A==",
+            "peer": true
+        },
         "node_modules/js-string-escape": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -18214,6 +20204,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "peer": true,
+            "dependencies": {
+                "invert-kv": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/lcov-parse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
@@ -18585,6 +20587,12 @@
                 "uc.micro": "^1.0.1"
             }
         },
+        "node_modules/listenercount": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+            "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+            "peer": true
+        },
         "node_modules/listr2": {
             "version": "3.13.1",
             "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.1.tgz",
@@ -18815,6 +20823,24 @@
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
             "dev": true
+        },
+        "node_modules/lodash.pad": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+            "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
+            "peer": true
+        },
+        "node_modules/lodash.padend": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+            "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+            "peer": true
+        },
+        "node_modules/lodash.padstart": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+            "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
+            "peer": true
         },
         "node_modules/log-driver": {
             "version": "1.2.7",
@@ -19103,7 +21129,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -19114,8 +21139,7 @@
         "node_modules/lru-cache/node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/lz-string": {
             "version": "1.4.4",
@@ -19519,6 +21543,33 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/memory-stream": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
+            "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
+            "peer": true,
+            "dependencies": {
+                "readable-stream": "~1.0.26-2"
+            }
+        },
+        "node_modules/memory-stream/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "peer": true
+        },
+        "node_modules/memory-stream/node_modules/readable-stream": {
+            "version": "1.0.34",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+            "peer": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            }
+        },
         "node_modules/meow": {
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -19766,6 +21817,37 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        },
+        "node_modules/minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "peer": true,
+            "dependencies": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minizlib/node_modules/minipass": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+            "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+            "peer": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minizlib/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "peer": true
         },
         "node_modules/mixin-deep": {
             "version": "1.3.2",
@@ -20762,6 +22844,191 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
             "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         },
+        "node_modules/mqtt": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.4.tgz",
+            "integrity": "sha512-yAVDfVHz3Cjn6K68z54mf7fTni/AWsPhiEsRwZSvet2wO47R6NFUn2psWxYIph2JxWtL3ZKa/da8pjJKSaXPdQ==",
+            "peer": true,
+            "dependencies": {
+                "commist": "^1.0.0",
+                "concat-stream": "^2.0.0",
+                "debug": "^4.1.1",
+                "duplexify": "^4.1.1",
+                "help-me": "^3.0.0",
+                "inherits": "^2.0.3",
+                "lru-cache": "^6.0.0",
+                "minimist": "^1.2.5",
+                "mqtt-packet": "^6.8.0",
+                "number-allocator": "^1.0.9",
+                "pump": "^3.0.0",
+                "readable-stream": "^3.6.0",
+                "reinterval": "^1.1.0",
+                "rfdc": "^1.3.0",
+                "split2": "^3.1.0",
+                "ws": "^7.5.5",
+                "xtend": "^4.0.2"
+            },
+            "bin": {
+                "mqtt": "bin/mqtt.js",
+                "mqtt_pub": "bin/pub.js",
+                "mqtt_sub": "bin/sub.js"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/mqtt-packet": {
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+            "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
+            "peer": true,
+            "dependencies": {
+                "bl": "^4.0.2",
+                "debug": "^4.1.1",
+                "process-nextick-args": "^2.0.1"
+            }
+        },
+        "node_modules/mqtt-packet/node_modules/debug": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "peer": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/mqtt-packet/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "peer": true
+        },
+        "node_modules/mqtt/node_modules/concat-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+            "engines": [
+                "node >= 6.0"
+            ],
+            "peer": true,
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "node_modules/mqtt/node_modules/debug": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "peer": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/mqtt/node_modules/duplexify": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+            "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+            "peer": true,
+            "dependencies": {
+                "end-of-stream": "^1.4.1",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "node_modules/mqtt/node_modules/minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "peer": true
+        },
+        "node_modules/mqtt/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "peer": true
+        },
+        "node_modules/mqtt/node_modules/pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "peer": true,
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "node_modules/mqtt/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "peer": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/mqtt/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "peer": true
+        },
+        "node_modules/mqtt/node_modules/split2": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+            "peer": true,
+            "dependencies": {
+                "readable-stream": "^3.0.0"
+            }
+        },
+        "node_modules/mqtt/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "peer": true,
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
         "node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -21300,6 +23567,39 @@
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
+        "node_modules/number-allocator": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.9.tgz",
+            "integrity": "sha512-sIIF0dZKMs3roPUD7rLreH8H3x47QKV9dHZ+PeSnH24gL0CxKxz/823woGZC0hLBSb2Ar/rOOeHiNbnPBum/Mw==",
+            "peer": true,
+            "dependencies": {
+                "debug": "^4.3.1",
+                "js-sdsl": "^2.1.2"
+            }
+        },
+        "node_modules/number-allocator/node_modules/debug": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "peer": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/number-allocator/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "peer": true
+        },
         "node_modules/number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -21794,6 +24094,18 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/os-locale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "peer": true,
+            "dependencies": {
+                "lcid": "^1.0.0"
+            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -23501,6 +25813,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/reinterval": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+            "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc=",
+            "peer": true
+        },
         "node_modules/release-zalgo": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
@@ -23838,6 +26156,12 @@
             "engines": {
                 "node": ">= 0.4.0"
             }
+        },
+        "node_modules/rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "peer": true
         },
         "node_modules/right-align": {
             "version": "0.1.3",
@@ -26041,6 +28365,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "peer": true
+        },
         "node_modules/setprototypeof": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -26725,6 +29055,12 @@
             "dependencies": {
                 "through2": "~2.0.0"
             }
+        },
+        "node_modules/splitargs": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
+            "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs=",
+            "peer": true
         },
         "node_modules/sprintf-js": {
             "version": "1.1.2",
@@ -27942,6 +30278,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/traverse": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+            "peer": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/trim": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -28008,8 +30353,7 @@
         "node_modules/tslib": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-            "dev": true
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         },
         "node_modules/tsscmp": {
             "version": "1.0.5",
@@ -28231,7 +30575,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -28310,6 +30653,50 @@
                 "node": ">=4"
             }
         },
+        "node_modules/unzipper": {
+            "version": "0.8.14",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
+            "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
+            "peer": true,
+            "dependencies": {
+                "big-integer": "^1.6.17",
+                "binary": "~0.3.0",
+                "bluebird": "~3.4.1",
+                "buffer-indexof-polyfill": "~1.0.0",
+                "duplexer2": "~0.1.4",
+                "fstream": "~1.0.10",
+                "listenercount": "~1.0.1",
+                "readable-stream": "~2.1.5",
+                "setimmediate": "~1.0.4"
+            }
+        },
+        "node_modules/unzipper/node_modules/bluebird": {
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+            "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+            "peer": true
+        },
+        "node_modules/unzipper/node_modules/process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "peer": true
+        },
+        "node_modules/unzipper/node_modules/readable-stream": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+            "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+            "peer": true,
+            "dependencies": {
+                "buffer-shims": "^1.0.0",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+            }
+        },
         "node_modules/upath": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -28369,6 +30756,12 @@
                 "punycode": "1.3.2",
                 "querystring": "0.2.0"
             }
+        },
+        "node_modules/url-join": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+            "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
+            "peer": true
         },
         "node_modules/url-parse": {
             "version": "1.4.7",
@@ -29082,10 +31475,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-            "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
-            "dev": true,
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+            "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
             "engines": {
                 "node": ">=8.3.0"
             },
@@ -29683,6 +32075,963 @@
         }
     },
     "dependencies": {
+        "@aws-crypto/crc32": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+            "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+            "requires": {
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/ie11-detection": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+            "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+            "requires": {
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/sha256-browser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+            "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "requires": {
+                "@aws-crypto/ie11-detection": "^2.0.0",
+                "@aws-crypto/sha256-js": "^2.0.0",
+                "@aws-crypto/supports-web-crypto": "^2.0.0",
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/sha256-js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "requires": {
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/supports-web-crypto": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+            "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+            "requires": {
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/util": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+            "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+            "requires": {
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-sdk/abort-controller": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.47.2.tgz",
+            "integrity": "sha512-OpxsJ3b2KlpqTQKq6Py6JtLhA7KaAtHthH1JLLWStaFhU5/Js8nFnfPWdJIDRLpuAGyeRTbkjOEUsOkWAI5dAw==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/chunked-blob-reader": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.47.1.tgz",
+            "integrity": "sha512-D8wcAumX+q/VlX6lbYHWJqsaDBvj1BHVjJlBwLPrUBcsk0bRaJhhbhesej6DkhRX2pFhwXlHgc7CAgYhJCtc/w==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/chunked-blob-reader-native": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.47.2.tgz",
+            "integrity": "sha512-29+ZWESaFDQ9QXo7RGcUMuP89GTKo8bKlYplzNsO/B1uG17LgTgVHBapU3UBlF/EkOh1rzN5tEW+XwwstHvlXg==",
+            "requires": {
+                "@aws-sdk/util-base64-browser": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/client-s3": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.48.0.tgz",
+            "integrity": "sha512-zOr7WWr9b5V3nTQnMTz+kjDpLJceI5Vmx3+mwi5a3vFDwJBvMJK0C25A9koDXtrjn8/hszAePh6+rC0oW8QJsQ==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/client-sts": "3.48.0",
+                "@aws-sdk/config-resolver": "3.47.2",
+                "@aws-sdk/credential-provider-node": "3.48.0",
+                "@aws-sdk/eventstream-serde-browser": "3.47.2",
+                "@aws-sdk/eventstream-serde-config-resolver": "3.47.2",
+                "@aws-sdk/eventstream-serde-node": "3.47.2",
+                "@aws-sdk/fetch-http-handler": "3.47.2",
+                "@aws-sdk/hash-blob-browser": "3.47.2",
+                "@aws-sdk/hash-node": "3.47.2",
+                "@aws-sdk/hash-stream-node": "3.47.2",
+                "@aws-sdk/invalid-dependency": "3.47.2",
+                "@aws-sdk/md5-js": "3.47.2",
+                "@aws-sdk/middleware-apply-body-checksum": "3.47.2",
+                "@aws-sdk/middleware-bucket-endpoint": "3.47.2",
+                "@aws-sdk/middleware-content-length": "3.47.2",
+                "@aws-sdk/middleware-expect-continue": "3.47.2",
+                "@aws-sdk/middleware-host-header": "3.47.2",
+                "@aws-sdk/middleware-location-constraint": "3.47.2",
+                "@aws-sdk/middleware-logger": "3.47.2",
+                "@aws-sdk/middleware-retry": "3.47.2",
+                "@aws-sdk/middleware-sdk-s3": "3.47.2",
+                "@aws-sdk/middleware-serde": "3.47.2",
+                "@aws-sdk/middleware-signing": "3.47.2",
+                "@aws-sdk/middleware-ssec": "3.47.2",
+                "@aws-sdk/middleware-stack": "3.47.2",
+                "@aws-sdk/middleware-user-agent": "3.47.2",
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/node-http-handler": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/smithy-client": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/url-parser": "3.47.2",
+                "@aws-sdk/util-base64-browser": "3.47.1",
+                "@aws-sdk/util-base64-node": "3.47.2",
+                "@aws-sdk/util-body-length-browser": "3.47.1",
+                "@aws-sdk/util-body-length-node": "3.47.1",
+                "@aws-sdk/util-defaults-mode-browser": "3.47.2",
+                "@aws-sdk/util-defaults-mode-node": "3.47.2",
+                "@aws-sdk/util-user-agent-browser": "3.47.2",
+                "@aws-sdk/util-user-agent-node": "3.47.2",
+                "@aws-sdk/util-utf8-browser": "3.47.1",
+                "@aws-sdk/util-utf8-node": "3.47.2",
+                "@aws-sdk/util-waiter": "3.47.2",
+                "@aws-sdk/xml-builder": "3.47.1",
+                "entities": "2.2.0",
+                "fast-xml-parser": "3.19.0",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/client-sso": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.48.0.tgz",
+            "integrity": "sha512-A9f7B5k+X7bx062OQEcLHIMMIq0H1GlUqdw9xReCLd6W6vcRthbeSK5xbkM7TzHeKHE2/9qQYAy0lyKkxFE6bQ==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.47.2",
+                "@aws-sdk/fetch-http-handler": "3.47.2",
+                "@aws-sdk/hash-node": "3.47.2",
+                "@aws-sdk/invalid-dependency": "3.47.2",
+                "@aws-sdk/middleware-content-length": "3.47.2",
+                "@aws-sdk/middleware-host-header": "3.47.2",
+                "@aws-sdk/middleware-logger": "3.47.2",
+                "@aws-sdk/middleware-retry": "3.47.2",
+                "@aws-sdk/middleware-serde": "3.47.2",
+                "@aws-sdk/middleware-stack": "3.47.2",
+                "@aws-sdk/middleware-user-agent": "3.47.2",
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/node-http-handler": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/smithy-client": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/url-parser": "3.47.2",
+                "@aws-sdk/util-base64-browser": "3.47.1",
+                "@aws-sdk/util-base64-node": "3.47.2",
+                "@aws-sdk/util-body-length-browser": "3.47.1",
+                "@aws-sdk/util-body-length-node": "3.47.1",
+                "@aws-sdk/util-defaults-mode-browser": "3.47.2",
+                "@aws-sdk/util-defaults-mode-node": "3.47.2",
+                "@aws-sdk/util-user-agent-browser": "3.47.2",
+                "@aws-sdk/util-user-agent-node": "3.47.2",
+                "@aws-sdk/util-utf8-browser": "3.47.1",
+                "@aws-sdk/util-utf8-node": "3.47.2",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/client-sts": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.48.0.tgz",
+            "integrity": "sha512-vOSIYCHjXB9nztZqwjIjV/jRZCfgej1YHpgqeNlfL8hPNhcrHemaoJaKHRPnhljIuHi+H5yQW7Pm4qJUFtGwKA==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.47.2",
+                "@aws-sdk/credential-provider-node": "3.48.0",
+                "@aws-sdk/fetch-http-handler": "3.47.2",
+                "@aws-sdk/hash-node": "3.47.2",
+                "@aws-sdk/invalid-dependency": "3.47.2",
+                "@aws-sdk/middleware-content-length": "3.47.2",
+                "@aws-sdk/middleware-host-header": "3.47.2",
+                "@aws-sdk/middleware-logger": "3.47.2",
+                "@aws-sdk/middleware-retry": "3.47.2",
+                "@aws-sdk/middleware-sdk-sts": "3.47.2",
+                "@aws-sdk/middleware-serde": "3.47.2",
+                "@aws-sdk/middleware-signing": "3.47.2",
+                "@aws-sdk/middleware-stack": "3.47.2",
+                "@aws-sdk/middleware-user-agent": "3.47.2",
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/node-http-handler": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/smithy-client": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/url-parser": "3.47.2",
+                "@aws-sdk/util-base64-browser": "3.47.1",
+                "@aws-sdk/util-base64-node": "3.47.2",
+                "@aws-sdk/util-body-length-browser": "3.47.1",
+                "@aws-sdk/util-body-length-node": "3.47.1",
+                "@aws-sdk/util-defaults-mode-browser": "3.47.2",
+                "@aws-sdk/util-defaults-mode-node": "3.47.2",
+                "@aws-sdk/util-user-agent-browser": "3.47.2",
+                "@aws-sdk/util-user-agent-node": "3.47.2",
+                "@aws-sdk/util-utf8-browser": "3.47.1",
+                "@aws-sdk/util-utf8-node": "3.47.2",
+                "entities": "2.2.0",
+                "fast-xml-parser": "3.19.0",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/config-resolver": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.47.2.tgz",
+            "integrity": "sha512-uv9U/qDOSqyCPQ71qiwMslqRMxYyt0y0h6X0aQ67GCPq4rbbU/dn8PqnYT0VfX/9Ss+DcbTm7vOTxVKv+8XADA==",
+            "requires": {
+                "@aws-sdk/signature-v4": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-config-provider": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/credential-provider-env": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.47.2.tgz",
+            "integrity": "sha512-HQKXY8y51kpTrD7P8fZJNf4MdCdu0+NcdOc+HScrQ21oZJv3BXUwXxKiOWY95Z3jYqyFwSKs1/FFuQ1mV0wjPg==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/credential-provider-imds": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.47.2.tgz",
+            "integrity": "sha512-7fCIofgU5pdKGgbCAYQ8H7sIFluN3oebFyFy7C4eXJyNy/8QKjFHEW3NkNCh0Bkd5sLOqkwYU3nyRx0CbNkEoQ==",
+            "requires": {
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/url-parser": "3.47.2",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/credential-provider-ini": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.48.0.tgz",
+            "integrity": "sha512-PSTfzK8V+3WVJOv+wlS4y09KYZx3iYj4Ad8LMGmGE4aqew8eRf6u2WuTmqrWwuOTxDra9PJ1ObcM5vBc+nZcYA==",
+            "requires": {
+                "@aws-sdk/credential-provider-env": "3.47.2",
+                "@aws-sdk/credential-provider-imds": "3.47.2",
+                "@aws-sdk/credential-provider-sso": "3.48.0",
+                "@aws-sdk/credential-provider-web-identity": "3.47.2",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-credentials": "3.47.2",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/credential-provider-node": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.48.0.tgz",
+            "integrity": "sha512-7CrbUT7yEZvYSQNXxZWN5KUx355wD+xrYIafoEST28T7nwcIiu7l2zpBY3JPhPIPNXqryVKfNQJvKV1dP3wF4g==",
+            "requires": {
+                "@aws-sdk/credential-provider-env": "3.47.2",
+                "@aws-sdk/credential-provider-imds": "3.47.2",
+                "@aws-sdk/credential-provider-ini": "3.48.0",
+                "@aws-sdk/credential-provider-process": "3.47.2",
+                "@aws-sdk/credential-provider-sso": "3.48.0",
+                "@aws-sdk/credential-provider-web-identity": "3.47.2",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-credentials": "3.47.2",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/credential-provider-process": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.47.2.tgz",
+            "integrity": "sha512-LBuABkVt/tdSoHy8hdGVnInZx5QADhK90dEHc41+HTTP3bCSNsSBIErkZnmhAD/3AGz7m/4qkPmhJOqzFisY/g==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-credentials": "3.47.2",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/credential-provider-sso": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.48.0.tgz",
+            "integrity": "sha512-31Ill3ZW35dueXb09PpOJ4C8oKdRGypbnycAgLYvvqYlO4LOs9FyQAsw+t2+ExvE6DznM0vkeWTQI3y7HUVYCA==",
+            "requires": {
+                "@aws-sdk/client-sso": "3.48.0",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-credentials": "3.47.2",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.47.2.tgz",
+            "integrity": "sha512-biJo8zJwNk8Dwrd/mkTcu8iLuOlGbsG2Uahta4StkOUhZ733xewOZ4WISLXVLocb/PXLM1lZQgkobwugpFOQRA==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/eventstream-marshaller": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.47.2.tgz",
+            "integrity": "sha512-KRWpWBuICxIJOp5vPe2NzT387uW8Q5IpyMNf8SNmFe9a9yTrg2oIRKkbEHHRNyCRnjbDmpU3Td58V9bpmaBXGw==",
+            "requires": {
+                "@aws-crypto/crc32": "2.0.0",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-hex-encoding": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/eventstream-serde-browser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.47.2.tgz",
+            "integrity": "sha512-dXjJ0eoNCu9P6uOzNcIL0OoXhVbdR/LPTRJCIR7NcfGCmJ4ZXeYwgYcHFTosrT/+SXAFGgsoU23dqA63TFWlMQ==",
+            "requires": {
+                "@aws-sdk/eventstream-marshaller": "3.47.2",
+                "@aws-sdk/eventstream-serde-universal": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/eventstream-serde-config-resolver": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.47.2.tgz",
+            "integrity": "sha512-LE481skmmWqoPhGyhFWqf/0eEtAFKSJqyzPZEer6yFUpejaijek4Heo6B+Y3cyDGoASuqY4Wum+9q1Z1xPn2BQ==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/eventstream-serde-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.47.2.tgz",
+            "integrity": "sha512-hrEsbDFaRr7rNJw+qgua+YhkMgSkgR/YhBe+rdI20maaJARIjLo4C8eRqAqrmlE4i2+PU4CvM/fVdL9M3HQXfQ==",
+            "requires": {
+                "@aws-sdk/eventstream-marshaller": "3.47.2",
+                "@aws-sdk/eventstream-serde-universal": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/eventstream-serde-universal": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.47.2.tgz",
+            "integrity": "sha512-Zkfa2kHKNsWSAdO4atr9+JPEtcZzWuJqZHMr8MO5aXAMnKd5BA9XvzyGyhrfpr9HmnoqcbXrcx8iqDxcFEIp5g==",
+            "requires": {
+                "@aws-sdk/eventstream-marshaller": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/fetch-http-handler": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.47.2.tgz",
+            "integrity": "sha512-MZwwKtJwkWPm3Tzh+F3gcts13v1OuZih0slOO4GJpMxq46+lcW4DoW04lNHULJsyduXs4CziH8g65DDh0Yhq6w==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/querystring-builder": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-base64-browser": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/hash-blob-browser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.47.2.tgz",
+            "integrity": "sha512-DG8kGFUqXH+eQLLQtzTuBxBEuLHJ03w3X2Geq7aNvfwh06OOJW3FYz+FTLH2f2HxqlKOQtf3MsqpH074zKC5/A==",
+            "requires": {
+                "@aws-sdk/chunked-blob-reader": "3.47.1",
+                "@aws-sdk/chunked-blob-reader-native": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/hash-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.47.2.tgz",
+            "integrity": "sha512-OpUCNGvchKI1WoOCtCm36gQtECMz2P5mJoXxAHNZQ5qQ69A5Vk/DZs1V24N94M7tl1u7ZpbLsJbWFdu+P4B27g==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-buffer-from": "3.47.2",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/hash-stream-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.47.2.tgz",
+            "integrity": "sha512-ModP4kZkkj4j1djuANwETAwYL1uTcXBHVcVLvy/wVDVLIcEW1TgGBgkY0rSGFE4RWDESTjhLCBKNDgvpxReSLQ==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/invalid-dependency": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.47.2.tgz",
+            "integrity": "sha512-QLIp0Gv9IbSVXru1kS92M4kF9ZgHmVP7Us8dWSu5UC7LJt6Uxhxjb+e+F0h9qY1Z3Prior12I4r5COgVO3dWxA==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/is-array-buffer": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.47.1.tgz",
+            "integrity": "sha512-HQMvT3dP6DCjmn87WkzYxUF9RqkvuXgKfddLEKj/tg/OgDQJv9xIPjEEry8Fd36ncbBqaBmC/z2ETZhpzHQvXA==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/md5-js": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.47.2.tgz",
+            "integrity": "sha512-APIz8mCPscYG6gCxvC2dbrBfpM3jHwAh+VqTmGHHxxO1AAP3y5ohtdl/2MsKtEPKuyT1IX2/YoUwcOyJj65xmw==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-utf8-browser": "3.47.1",
+                "@aws-sdk/util-utf8-node": "3.47.2",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-apply-body-checksum": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.47.2.tgz",
+            "integrity": "sha512-sjZZZ7hOR9retsblYOs4cgsVg7r1Sfuvr/aIx16XXv3TeAk7fz8JTRf5STxMM6YkGIVMbvBOHpMNvcGGgJQhZQ==",
+            "requires": {
+                "@aws-sdk/is-array-buffer": "3.47.1",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-bucket-endpoint": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.47.2.tgz",
+            "integrity": "sha512-VrUrkAUS3CqI7tK3r0c0oT+1SE1L+euyq6j6Jt3XOjRMUXCkArecVkr3jEprbpVDiAkaTXEJE77iL1+98twiYA==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-arn-parser": "3.47.1",
+                "@aws-sdk/util-config-provider": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-content-length": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.47.2.tgz",
+            "integrity": "sha512-rpLtN6BczAfJnH1fpXyUOMdDFN3xrky3QZ4SULVgTLXNMOvN5zDJnjwUh/QNgEaEQhxd6lroVJSgosG3357kWg==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-expect-continue": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.47.2.tgz",
+            "integrity": "sha512-sLv5q8+POzpMvp9dx/OInFr6VWJreHOGFoauYN1n7a+8dmhr9tycBLq/j+eBXI2FWwC3dXCBdrC9qs4ieSRe0Q==",
+            "requires": {
+                "@aws-sdk/middleware-header-default": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-header-default": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.47.2.tgz",
+            "integrity": "sha512-fCcQaQ/ac+h8nS8d8nSrvP/scNTCdkHQ8PpNXo7nSz4a67xbxxln61T4iHOin8z0m62NlFrhtMdlQTtDqDEZVg==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-host-header": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.47.2.tgz",
+            "integrity": "sha512-sDIGydvdO1LC7VQntTDMK+YYLRVCJAhrsCT8SxyAX0Jhu7Ek1BfRZzSZDwapL+idbMyyKsB80NpNoTWuKRrrew==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-location-constraint": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.47.2.tgz",
+            "integrity": "sha512-b6ozPYnInQB1Iv+UjLyhunTCUcw54AKtUO7Mj2QLT2GqCPDPry7ZmAC9Qtfv4Itv7HyM4VfR1roAGKZwT4zxQw==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-logger": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.47.2.tgz",
+            "integrity": "sha512-Oz14cAaYmtzMYw0/ehlVLvMF4gqQS0qaYWGyyR4a3nONiwEDzxNMEQiEg7i8VgsP4usK7lfYZLXgwSmqo7uCzg==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-retry": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.47.2.tgz",
+            "integrity": "sha512-qgAE/+hVGXQDkqbVo+uFeb+N7mr7kBi0Oc1Fm490fm3uLQnXuyu3suIix//wxNejoLwIgKQGSLrQNgnXtuvhxw==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/service-error-classification": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0",
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                }
+            }
+        },
+        "@aws-sdk/middleware-sdk-s3": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.47.2.tgz",
+            "integrity": "sha512-KjcrHHDIn4QCh8pTRVT2u8uOnpdPYVB2p+xblwyRvJt2VLhgJbgNpRy8pOwNo2lyfbOKrmWeBk4x0NduiXle8g==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/signature-v4": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-arn-parser": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.47.2.tgz",
+            "integrity": "sha512-KlO4cYb4Bxf/Jg/uxlxRrFvxUR/DmjMIS+JRZNGqK4XyYA+apYZkfM0XUtMiKc491n/euluf9A0AyTxpMgixxg==",
+            "requires": {
+                "@aws-sdk/middleware-signing": "3.47.2",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/signature-v4": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-serde": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.47.2.tgz",
+            "integrity": "sha512-Gjw+fkG4UvvbP5LrGW1FzUq0IJB6QIBFxStE0gbyjkKNYtcb9c0R3dIwH5CSECtelDZScytwmBKaVe8NGi6wJA==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-signing": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.47.2.tgz",
+            "integrity": "sha512-r6/2gf5gwkVdI7EOa1TdYdfzOdCF3jkhjLi98c3nAxZNxZFGwoycIy7Bd6sCfOdcmk8NyVmR0APpsgD9q+a3nw==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/signature-v4": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-ssec": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.47.2.tgz",
+            "integrity": "sha512-dRNQJjvlg4omfhAfSYtZva4OpS/58aLO7y8l2o5sQHGPwob5OYO5zfPioi4h68UZw1fagG962hUywOkVJDJAuw==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-stack": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.47.2.tgz",
+            "integrity": "sha512-9wedI1L92stvg5fs6Y3CbUXYLZIYdI3Mrdqex+ulNRuepgZNORsk+dnb8rTkf9cO3nuWRrnfKBLc/uiTcA1dww==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/middleware-user-agent": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.47.2.tgz",
+            "integrity": "sha512-LF5gOi37lJ3tkuDSqZVKHmqYY8oTIUTEdmPVUbBQtPKsx9xfCNbMNVAP+C+7bnbt6StZIZsvtu0M144yNFXPGQ==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/node-config-provider": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.47.2.tgz",
+            "integrity": "sha512-POdigo6ZXLRVWhmjE21Y1Q1ziPnM/c3rH0wHgzAtdx0Mfn6/9jS77QHMkZzC8MJ7lzgXVFDWM25evVZqdYrh+g==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/node-http-handler": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.47.2.tgz",
+            "integrity": "sha512-X2Y+H2DBoeDnrSe5rsVc63uhext230AuG/+hIFHK2/HkyG9DiiHKNCNj2w8N4FLWEX3l8KDif3C7BqYxj9ZkDg==",
+            "requires": {
+                "@aws-sdk/abort-controller": "3.47.2",
+                "@aws-sdk/protocol-http": "3.47.2",
+                "@aws-sdk/querystring-builder": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/property-provider": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.47.2.tgz",
+            "integrity": "sha512-0NiVJ6+JtRC8XOvNb1ofHtsjINrinC1/fDKvl/bDtJDhehC5EcIeiDQmHFUhGsgTyD+VpmuHj7E4AlV6BchNPQ==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/protocol-http": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.47.2.tgz",
+            "integrity": "sha512-XAQFbSigJD0fk61nSR6y6TMv3+o1IjymltWuDmGEtoI25pisC2M3A+3/xO9YHag/41CSgt9nQ+lh1iC4UlKKJw==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/querystring-builder": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.47.2.tgz",
+            "integrity": "sha512-rsckQ262jFSDVES6rOuTnSDM9XEbM57zxeBj5BtD6eCnyUD0G4FZa1xZRum4khoxfff6/eJ+i2uncKrEk1v+EQ==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-uri-escape": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/querystring-parser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.47.2.tgz",
+            "integrity": "sha512-28BirdFhZ+Y2pUMuI9r1ATgcQyt4q3cSqqpLSy7ADGb7xHde6oA/ZfRdX/s7OVIHoAfhrjAeI+TbYjwso9F/HA==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/service-error-classification": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.47.2.tgz",
+            "integrity": "sha512-oJCJbAPYhTNguJUhD8hlD7ibWIDpkvGrhkcq89gxBcXHPl/2/kjsii0gr302IH452IJlumpVe5wOXoZeqZYjaw=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.47.1.tgz",
+            "integrity": "sha512-f0eVOMYkT4H0gOf1B9lw65/xeTa7rT9hocVB7DbjWk8Ifv46Uvlb4ZyYOLZIBDQyFNFrD/HHvja3BkzfV0MEOA==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/signature-v4": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.47.2.tgz",
+            "integrity": "sha512-zJIhUY8LLiQldfM9wpgVw525dHbILJovyZm3xmm6Tq/t258cawNaeOvOp9w0I3ycA3gs+nKgMXdeMjLH8QLbWg==",
+            "requires": {
+                "@aws-sdk/is-array-buffer": "3.47.1",
+                "@aws-sdk/types": "3.47.1",
+                "@aws-sdk/util-hex-encoding": "3.47.1",
+                "@aws-sdk/util-uri-escape": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/signature-v4-crt": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.47.2.tgz",
+            "integrity": "sha512-ImDwJ9UFvssEK5xIBzsQPWnvPL/BXLrYQQnSwv258/wJeAtGTJefz2quqkDax11IkphZMg8ieeSZ7k0CJh5Ktg==",
+            "peer": true,
+            "requires": {
+                "@aws-sdk/is-array-buffer": "3.47.1",
+                "@aws-sdk/querystring-parser": "3.47.2",
+                "@aws-sdk/signature-v4": "3.47.2",
+                "@aws-sdk/util-hex-encoding": "3.47.1",
+                "@aws-sdk/util-uri-escape": "3.47.1",
+                "aws-crt": "^1.9.7",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/smithy-client": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.47.2.tgz",
+            "integrity": "sha512-vCzZodWyKmLzC+N/B1GzDjKD8I5b/ILTwPHaaH7yJdncISq/3jyTMJVW7mZHbDX61a18rL/bADnIxEd524Y2hQ==",
+            "requires": {
+                "@aws-sdk/middleware-stack": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/types": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.1.tgz",
+            "integrity": "sha512-c+lxJJLD5Bq8HkrgaIWQfK8oGH53CYpRRJizyQ5qfRo9aXp/qshUnIVcgnA8t0k7jfzcIfa0Q7jSSBw3EerEbg=="
+        },
+        "@aws-sdk/url-parser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.47.2.tgz",
+            "integrity": "sha512-xapm+8toLY1FJmdGWl/YWCGSbbzPitiKmcg9+NP1DIyZyHjzeG5vBZ2SYejYtGOf+Qn1VKyNN2+Qs049FOsh6w==",
+            "requires": {
+                "@aws-sdk/querystring-parser": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-arn-parser": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.47.1.tgz",
+            "integrity": "sha512-Q+tZjYyBeWMyPJ6+l42JXS7gt5crXywJbLDGjoLoS+Ba0JDB5zp8IMRLzGzQpTO+VnbL4ZyEEUVEihyqFbB0iw==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-base64-browser": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.47.1.tgz",
+            "integrity": "sha512-asStae2d1xvgs3czWvvVb4JWHfY2iV8yximL4MwF+Lb8XG/b8LH3tG1E5axAFVMBcljdvRB941N7w3rug7V9ig==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-base64-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.47.2.tgz",
+            "integrity": "sha512-0Oml66+9/uERV1dosecA/1tEd0zdiwI3kEobCF5w2f4gJDzUdaEoztcRwtbLcFv6yVT7XoW4evMQbtlcruypcQ==",
+            "requires": {
+                "@aws-sdk/util-buffer-from": "3.47.2",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-body-length-browser": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.47.1.tgz",
+            "integrity": "sha512-qR307MATPC+4JtN7W9sSkchfdB3O4mulLKRpk7rF6Ns6vVwhaPfJstSGe9Qa68zYZXubF9h5WnoWuJz4N0Vqdw==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-body-length-node": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.47.1.tgz",
+            "integrity": "sha512-U2K7+gi3bAQBb3WB1/trvA+4rPC2SKH9w/sRtqBwtxHNOjXjiCiF3oEYnbir7cdSfhzMH4HBYKbfkHZwTAHMfw==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-buffer-from": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.47.2.tgz",
+            "integrity": "sha512-oLytLGiIeJEk7FcT7bdeQNv7+vvVVPuL5hyXlCjHZwoWuDxepjoDhTaIC9Isq1UyPKfSZaVpk/1nqREe4aYDHw==",
+            "requires": {
+                "@aws-sdk/is-array-buffer": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-config-provider": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.47.1.tgz",
+            "integrity": "sha512-kBs+YghZaOqChxLZDTR8dw5RQxJ/qF064EjRpC+TdCegLCO2UtZ97RXBvc5mdt94OxXGjGUjDiD/eAlpjjFNXw==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-credentials": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.47.2.tgz",
+            "integrity": "sha512-C0L8pfZkJyWfuvLVRcM2Ff11t2mkM4lzjNBnQKdL80wuASZWCnAi50oUKBgwbHZdOsRKGV7C4zqAuTLTRaFpCQ==",
+            "requires": {
+                "@aws-sdk/shared-ini-file-loader": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.47.2.tgz",
+            "integrity": "sha512-ojAF5k/VFbPvJoj6/G6ekVQhbFvabUBvRhRaoQjkmj8LVEahtzcNcOxhu3FmH17mXR2oxWsGwvq6VAw6V3jLBg==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.47.2.tgz",
+            "integrity": "sha512-O35bXeahlepgPxg72XDN+5cXlbs+jZec5AH+7YYI+ldEVu6WxF0MxeQtMG4Fqpb19bpPIPz0SodHM1D1I53S5w==",
+            "requires": {
+                "@aws-sdk/config-resolver": "3.47.2",
+                "@aws-sdk/credential-provider-imds": "3.47.2",
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/property-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-hex-encoding": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.47.1.tgz",
+            "integrity": "sha512-9vBhp1E74s6nImK5xk7BkopQ10w6Vk8UrIinu71U7V/0PdjCEb4Jmnn++MLyim2jTT0QEGmJ6v0VjPZi9ETWaA==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-locate-window": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.1.tgz",
+            "integrity": "sha512-dMcBhtyJ7ZMNS8RS4UOVbkiR0gGrBWv+p1s9NLfMNXod9zaTAlMIKl9de8Xdshguvc8//J7heQV/7+HMvFEq2g==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-uri-escape": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.47.1.tgz",
+            "integrity": "sha512-CGqm+bT07OCJSgDo48/4Fegh9tNPR3kcOMfNWZ/J6lrt+nfAnOdXx5zZB63PjKCt5zJ7LM0thOQgAeOf2WdJzQ==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.47.2.tgz",
+            "integrity": "sha512-dstakqLW8hXRMzR/s3uLpfYbMs/qDowG/Fp123cAuln4rUODG29VNFLkMAYRnG6RQ9hf2OtXsCfFGNSm+bnJMg==",
+            "requires": {
+                "@aws-sdk/types": "3.47.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-user-agent-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.47.2.tgz",
+            "integrity": "sha512-9wYkGvTrOFWb+9QjziQma+l9M0u1tmHiIdL9r4Btsc9WVMsy1Y9HUUeXacM3dLLIzCpQ5dDbjIlAZWA8Rm3ZOQ==",
+            "requires": {
+                "@aws-sdk/node-config-provider": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-utf8-browser": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.47.1.tgz",
+            "integrity": "sha512-PzHEdiBhfnZbHvZ+dIlIPodDbpgrpKDYslHe9A+tH8ZfuAxxmZEqnukp7QEkFr6mBcmq3H2thcPdNT45/5pA7Q==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-utf8-node": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.47.2.tgz",
+            "integrity": "sha512-itgWlytqhbD/pRiGxX7XY7RF8k15ScV816FUlZtOKeRpAphliFT07TGWKmiZcFxEbHpi9r8A5H1FOoPmyU635Q==",
+            "requires": {
+                "@aws-sdk/util-buffer-from": "3.47.2",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/util-waiter": {
+            "version": "3.47.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.47.2.tgz",
+            "integrity": "sha512-3zzOEDPRgHJ3o17Ri0vVmCKvqh9tA2lP9WbpXTjOgEAfdI/hsP2XhqJWVrlyN+wQ6FwPbuX3Jsb7lsp1OZP2bg==",
+            "requires": {
+                "@aws-sdk/abort-controller": "3.47.2",
+                "@aws-sdk/types": "3.47.1",
+                "tslib": "^2.3.0"
+            }
+        },
+        "@aws-sdk/xml-builder": {
+            "version": "3.47.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.47.1.tgz",
+            "integrity": "sha512-SPDSKG7zw7MnGFVl3uIVNBBZo4WyNg8Wu82COfD8XaH+E/XiYiHjjoPq8eIscrQb799TXudHxy5h/C7dFACMxA==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
         "@babel/code-frame": {
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -30770,6 +34119,48 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
                     "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
                     "dev": true
+                }
+            }
+        },
+        "@httptoolkit/websocket-stream": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.0.tgz",
+            "integrity": "sha512-EC8m9JbhpGX2okfvLakqrmy4Le0VyNKR7b3IdvFZR/BfFO4ruh/XceBvXhCFHkykchnFxuOSlRwFiqNSXlwcGA==",
+            "peer": true,
+            "requires": {
+                "@types/ws": "*",
+                "duplexify": "^3.5.1",
+                "inherits": "^2.0.1",
+                "isomorphic-ws": "^4.0.1",
+                "readable-stream": "^2.3.3",
+                "safe-buffer": "^5.1.2",
+                "ws": "*",
+                "xtend": "^4.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "peer": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "peer": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
                 }
             }
         },
@@ -32791,6 +36182,60 @@
                 "@babel/runtime": "^7.12.5"
             }
         },
+        "@tokenizer/range": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@tokenizer/range/-/range-0.4.1.tgz",
+            "integrity": "sha512-GOfl0wtGJIIg1OqxOO3P2BAZqDhuxMDviIAi7dy3nHC629css5Rk77LXL6ljyY6yRI+KWBYlJOcb0lPj99tbZQ==",
+            "requires": {
+                "debug": "^4.1.1",
+                "strtok3": "^6.0.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
+            }
+        },
+        "@tokenizer/s3": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/s3/-/s3-0.2.0.tgz",
+            "integrity": "sha512-v6KDDP6SsYydNAAt7AVkOocjDKCTp3puuCA0UVPR/eFLU+NYwOkfIWhRjdXMG9LzItoDK+kn7ACawJmAHM+F9w==",
+            "requires": {
+                "@tokenizer/range": "^0.4.0",
+                "strtok3": "6.1.3"
+            },
+            "dependencies": {
+                "@tokenizer/token": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
+                    "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+                },
+                "peek-readable": {
+                    "version": "3.1.4",
+                    "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.4.tgz",
+                    "integrity": "sha512-DX7ec7frSMtCWw+zMd27f66hcxIz/w9LQTY2RflB4WNHCVPAye1pJiP2t3gvaaOhu7IOhtPbHw8MemMj+F5lrg=="
+                },
+                "strtok3": {
+                    "version": "6.1.3",
+                    "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.1.3.tgz",
+                    "integrity": "sha512-ssWSKFOeUTurMSucgyUf+a6Z9mVTYrsYiyEK5RLnh8BM6sFrKSljVlnjZXIDxMguYfdQI+mUPFHo88FYTxq1XA==",
+                    "requires": {
+                        "@tokenizer/token": "^0.1.1",
+                        "peek-readable": "^3.1.4"
+                    }
+                }
+            }
+        },
         "@tokenizer/token": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -32900,8 +36345,7 @@
         "@types/node": {
             "version": "15.12.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-            "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
-            "dev": true
+            "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww=="
         },
         "@types/prettier": {
             "version": "2.3.0",
@@ -32934,6 +36378,15 @@
             "dev": true,
             "requires": {
                 "@types/jest": "*"
+            }
+        },
+        "@types/ws": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
+            "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+            "peer": true,
+            "requires": {
+                "@types/node": "*"
             }
         },
         "@types/yargs": {
@@ -33318,6 +36771,12 @@
                 }
             }
         },
+        "ansi": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+            "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+            "peer": true
+        },
         "ansi-align": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -33599,6 +37058,59 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+        },
+        "aws-crt": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.10.6.tgz",
+            "integrity": "sha512-LCOFwFdUk3NJNUkm0YuiqU2jPtnC5OZYeLqIZyqVzDoSpK2wL7QAaA553v4YPA5xs3QU7jCmaDl6y3LjJTm4+w==",
+            "peer": true,
+            "requires": {
+                "@httptoolkit/websocket-stream": "^6.0.0",
+                "axios": "^0.24.0",
+                "cmake-js": "6.3.0",
+                "crypto-js": "^4.0.0",
+                "fastestsmallesttextencoderdecoder": "^1.0.22",
+                "mqtt": "^4.3.4",
+                "tar": "^6.1.11",
+                "ws": "^7.5.5"
+            },
+            "dependencies": {
+                "minipass": {
+                    "version": "3.1.6",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+                    "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+                    "peer": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "peer": true
+                },
+                "tar": {
+                    "version": "6.1.11",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+                    "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+                    "peer": true,
+                    "requires": {
+                        "chownr": "^2.0.0",
+                        "fs-minipass": "^2.0.0",
+                        "minipass": "^3.0.0",
+                        "minizlib": "^2.1.1",
+                        "mkdirp": "^1.0.3",
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "peer": true
+                }
+            }
         },
         "aws-sdk": {
             "version": "2.940.0",
@@ -33948,6 +37460,22 @@
                 "callsite": "1.0.0"
             }
         },
+        "big-integer": {
+            "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "peer": true
+        },
+        "binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+            "peer": true,
+            "requires": {
+                "buffers": "~0.1.1",
+                "chainsaw": "~0.1.0"
+            }
+        },
         "binary-extensions": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -33975,6 +37503,55 @@
                 "buffer-more-ints": "~1.0.0",
                 "debug": "~2.6.9",
                 "safe-buffer": "~5.1.2"
+            }
+        },
+        "bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "peer": true,
+            "requires": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+                    "peer": true,
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.1.13"
+                    }
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "peer": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                    "peer": true
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                    "peer": true,
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                }
             }
         },
         "blob-util": {
@@ -34034,6 +37611,11 @@
             "requires": {
                 "hoek": "2.x.x"
             }
+        },
+        "bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "boxen": {
             "version": "1.3.0",
@@ -34159,6 +37741,12 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
         },
+        "buffer-indexof-polyfill": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "peer": true
+        },
         "buffer-more-ints": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
@@ -34173,6 +37761,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
             "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+        },
+        "buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+            "peer": true
         },
         "busboy": {
             "version": "0.2.14",
@@ -34347,6 +37941,15 @@
                 "type-detect": "^4.0.5"
             }
         },
+        "chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+            "peer": true,
+            "requires": {
+                "traverse": ">=0.3.0 <0.4"
+            }
+        },
         "chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -34464,6 +38067,12 @@
                     }
                 }
             }
+        },
+        "chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "peer": true
         },
         "ci-info": {
             "version": "1.6.0",
@@ -34692,6 +38301,264 @@
                 }
             }
         },
+        "cmake-js": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.0.tgz",
+            "integrity": "sha512-1uqTOmFt6BIqKlrX+39/aewU/JVhyZWDqwAL+6psToUwxj3yWPJiwxiZFmV0XdcoWmqGs7peZTxTbJtAcH8hxw==",
+            "peer": true,
+            "requires": {
+                "axios": "^0.21.1",
+                "debug": "^4",
+                "fs-extra": "^5.0.0",
+                "is-iojs": "^1.0.1",
+                "lodash": "^4",
+                "memory-stream": "0",
+                "npmlog": "^1.2.0",
+                "rc": "^1.2.7",
+                "semver": "^5.0.3",
+                "splitargs": "0",
+                "tar": "^4",
+                "unzipper": "^0.8.13",
+                "url-join": "0",
+                "which": "^1.0.9",
+                "yargs": "^3.6.0"
+            },
+            "dependencies": {
+                "are-we-there-yet": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+                    "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
+                    "peer": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.0 || ^1.1.13"
+                    }
+                },
+                "axios": {
+                    "version": "0.21.4",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+                    "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+                    "peer": true,
+                    "requires": {
+                        "follow-redirects": "^1.14.0"
+                    }
+                },
+                "camelcase": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+                    "peer": true
+                },
+                "chownr": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+                    "peer": true
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "peer": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "peer": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+                    "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+                    "peer": true
+                },
+                "fs-extra": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+                    "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+                    "peer": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "fs-minipass": {
+                    "version": "1.2.7",
+                    "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+                    "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+                    "peer": true,
+                    "requires": {
+                        "minipass": "^2.6.0"
+                    }
+                },
+                "gauge": {
+                    "version": "1.2.7",
+                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+                    "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+                    "peer": true,
+                    "requires": {
+                        "ansi": "^0.3.0",
+                        "has-unicode": "^2.0.0",
+                        "lodash.pad": "^4.1.0",
+                        "lodash.padend": "^4.1.0",
+                        "lodash.padstart": "^4.1.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "peer": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+                    "peer": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "peer": true
+                },
+                "minizlib": {
+                    "version": "1.3.3",
+                    "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+                    "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+                    "peer": true,
+                    "requires": {
+                        "minipass": "^2.9.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "peer": true
+                },
+                "npmlog": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+                    "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+                    "peer": true,
+                    "requires": {
+                        "ansi": "~0.3.0",
+                        "are-we-there-yet": "~1.0.0",
+                        "gauge": "~1.2.0"
+                    }
+                },
+                "rc": {
+                    "version": "1.2.8",
+                    "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+                    "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+                    "peer": true,
+                    "requires": {
+                        "deep-extend": "^0.6.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                    "peer": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "peer": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "peer": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "tar": {
+                    "version": "4.4.19",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+                    "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+                    "peer": true,
+                    "requires": {
+                        "chownr": "^1.1.4",
+                        "fs-minipass": "^1.2.7",
+                        "minipass": "^2.9.0",
+                        "minizlib": "^1.3.3",
+                        "mkdirp": "^0.5.5",
+                        "safe-buffer": "^5.2.1",
+                        "yallist": "^3.1.1"
+                    }
+                },
+                "window-size": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+                    "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+                    "peer": true
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+                    "peer": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
+                    }
+                },
+                "y18n": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+                    "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+                    "peer": true
+                },
+                "yallist": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+                    "peer": true
+                },
+                "yargs": {
+                    "version": "3.32.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+                    "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+                    "peer": true,
+                    "requires": {
+                        "camelcase": "^2.0.1",
+                        "cliui": "^3.0.3",
+                        "decamelize": "^1.1.1",
+                        "os-locale": "^1.4.0",
+                        "string-width": "^1.0.1",
+                        "window-size": "^0.1.4",
+                        "y18n": "^3.2.0"
+                    }
+                }
+            }
+        },
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -34764,6 +38631,30 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "commist": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+            "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
+            "peer": true,
+            "requires": {
+                "leven": "^2.1.0",
+                "minimist": "^1.1.0"
+            },
+            "dependencies": {
+                "leven": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+                    "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+                    "peer": true
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "peer": true
+                }
+            }
         },
         "common-tags": {
             "version": "1.8.0",
@@ -35248,6 +39139,12 @@
             "resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
             "integrity": "sha1-RwqBuGvkxe4XrMggeh9TFa4g27A=",
             "dev": true
+        },
+        "crypto-js": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+            "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
+            "peer": true
         },
         "crypto-random-string": {
             "version": "1.0.0",
@@ -36250,6 +40147,41 @@
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
         },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "peer": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "peer": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "peer": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
         "duplexer3": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -36423,8 +40355,7 @@
         "entities": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-            "dev": true
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         },
         "errlop": {
             "version": "2.2.0",
@@ -37128,6 +41059,17 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
+        "fast-xml-parser": {
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+            "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+        },
+        "fastestsmallesttextencoderdecoder": {
+            "version": "1.0.22",
+            "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+            "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+            "peer": true
+        },
         "faye-websocket": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -37419,6 +41361,32 @@
                 "klaw": "^1.0.0",
                 "path-is-absolute": "^1.0.0",
                 "rimraf": "^2.2.8"
+            }
+        },
+        "fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "peer": true,
+            "requires": {
+                "minipass": "^3.0.0"
+            },
+            "dependencies": {
+                "minipass": {
+                    "version": "3.1.6",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+                    "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+                    "peer": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "peer": true
+                }
             }
         },
         "fs-promise": {
@@ -38894,6 +42862,44 @@
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
         },
+        "help-me": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+            "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
+            "peer": true,
+            "requires": {
+                "glob": "^7.1.6",
+                "readable-stream": "^3.6.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "peer": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                    "peer": true
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                    "peer": true,
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                }
+            }
+        },
         "hoek": {
             "version": "2.16.3",
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -39334,6 +43340,12 @@
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
             "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls="
         },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "peer": true
+        },
         "ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -39564,6 +43576,12 @@
                 "is-path-inside": "^1.0.0"
             }
         },
+        "is-iojs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
+            "integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
+            "peer": true
+        },
         "is-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
@@ -39757,6 +43775,13 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "isomorphic-ws": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+            "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+            "peer": true,
+            "requires": {}
         },
         "isstream": {
             "version": "0.1.2",
@@ -43228,6 +47253,12 @@
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.3.tgz",
             "integrity": "sha512-fiUvdfCaAXoQTHdKMgTvg6IkecXDcVz6V5rlftUTclF9IKBjMizvSdQaCl/z/6TApDeby5NL+axYou3i0mu1Pg=="
         },
+        "js-sdsl": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+            "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A==",
+            "peer": true
+        },
         "js-string-escape": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -43691,6 +47722,15 @@
             "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
             "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
         },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "peer": true,
+            "requires": {
+                "invert-kv": "^1.0.0"
+            }
+        },
         "lcov-parse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
@@ -43982,6 +48022,12 @@
                 "uc.micro": "^1.0.1"
             }
         },
+        "listenercount": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+            "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+            "peer": true
+        },
         "listr2": {
             "version": "3.13.1",
             "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.1.tgz",
@@ -44173,6 +48219,24 @@
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
             "dev": true
+        },
+        "lodash.pad": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+            "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
+            "peer": true
+        },
+        "lodash.padend": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+            "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+            "peer": true
+        },
+        "lodash.padstart": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+            "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
+            "peer": true
         },
         "log-driver": {
             "version": "1.2.7",
@@ -44384,7 +48448,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
             },
@@ -44392,8 +48455,7 @@
                 "yallist": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
                 }
             }
         },
@@ -44736,6 +48798,35 @@
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
         },
+        "memory-stream": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
+            "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
+            "peer": true,
+            "requires": {
+                "readable-stream": "~1.0.26-2"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "peer": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "peer": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                }
+            }
+        },
         "meow": {
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -44945,6 +49036,33 @@
                     "version": "3.1.1",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
                     "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+                }
+            }
+        },
+        "minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "peer": true,
+            "requires": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "minipass": {
+                    "version": "3.1.6",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+                    "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+                    "peer": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "peer": true
                 }
             }
         },
@@ -45698,6 +49816,151 @@
                 }
             }
         },
+        "mqtt": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.4.tgz",
+            "integrity": "sha512-yAVDfVHz3Cjn6K68z54mf7fTni/AWsPhiEsRwZSvet2wO47R6NFUn2psWxYIph2JxWtL3ZKa/da8pjJKSaXPdQ==",
+            "peer": true,
+            "requires": {
+                "commist": "^1.0.0",
+                "concat-stream": "^2.0.0",
+                "debug": "^4.1.1",
+                "duplexify": "^4.1.1",
+                "help-me": "^3.0.0",
+                "inherits": "^2.0.3",
+                "lru-cache": "^6.0.0",
+                "minimist": "^1.2.5",
+                "mqtt-packet": "^6.8.0",
+                "number-allocator": "^1.0.9",
+                "pump": "^3.0.0",
+                "readable-stream": "^3.6.0",
+                "reinterval": "^1.1.0",
+                "rfdc": "^1.3.0",
+                "split2": "^3.1.0",
+                "ws": "^7.5.5",
+                "xtend": "^4.0.2"
+            },
+            "dependencies": {
+                "concat-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+                    "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+                    "peer": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^3.0.2",
+                        "typedarray": "^0.0.6"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "peer": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "duplexify": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+                    "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+                    "peer": true,
+                    "requires": {
+                        "end-of-stream": "^1.4.1",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^3.1.1",
+                        "stream-shift": "^1.0.0"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "peer": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "peer": true
+                },
+                "pump": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                    "peer": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "peer": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                    "peer": true
+                },
+                "split2": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+                    "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+                    "peer": true,
+                    "requires": {
+                        "readable-stream": "^3.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                    "peer": true,
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                }
+            }
+        },
+        "mqtt-packet": {
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+            "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
+            "peer": true,
+            "requires": {
+                "bl": "^4.0.2",
+                "debug": "^4.1.1",
+                "process-nextick-args": "^2.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "peer": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "peer": true
+                }
+            }
+        },
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -46137,6 +50400,33 @@
                 "boolbase": "^1.0.0"
             }
         },
+        "number-allocator": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.9.tgz",
+            "integrity": "sha512-sIIF0dZKMs3roPUD7rLreH8H3x47QKV9dHZ+PeSnH24gL0CxKxz/823woGZC0hLBSb2Ar/rOOeHiNbnPBum/Mw==",
+            "peer": true,
+            "requires": {
+                "debug": "^4.3.1",
+                "js-sdsl": "^2.1.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "peer": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "peer": true
+                }
+            }
+        },
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -46502,6 +50792,15 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+        },
+        "os-locale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "peer": true,
+            "requires": {
+                "lcid": "^1.0.0"
+            }
         },
         "os-tmpdir": {
             "version": "1.0.2",
@@ -47855,6 +52154,12 @@
                 "rc": "^1.0.1"
             }
         },
+        "reinterval": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+            "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc=",
+            "peer": true
+        },
         "release-zalgo": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
@@ -48122,6 +52427,12 @@
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
             "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
+        },
+        "rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "peer": true
         },
         "right-align": {
             "version": "0.1.3",
@@ -49998,6 +54309,12 @@
                 }
             }
         },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "peer": true
+        },
         "setprototypeof": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -50591,6 +54908,12 @@
             "requires": {
                 "through2": "~2.0.0"
             }
+        },
+        "splitargs": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
+            "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs=",
+            "peer": true
         },
         "sprintf-js": {
             "version": "1.1.2",
@@ -51580,6 +55903,12 @@
                 "punycode": "^2.1.1"
             }
         },
+        "traverse": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+            "peer": true
+        },
         "trim": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -51630,8 +55959,7 @@
         "tslib": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-            "dev": true
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         },
         "tsscmp": {
             "version": "1.0.5",
@@ -51807,8 +56135,7 @@
         "universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
         "unpipe": {
             "version": "1.0.0",
@@ -51867,6 +56194,52 @@
             "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
             "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
         },
+        "unzipper": {
+            "version": "0.8.14",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
+            "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
+            "peer": true,
+            "requires": {
+                "big-integer": "^1.6.17",
+                "binary": "~0.3.0",
+                "bluebird": "~3.4.1",
+                "buffer-indexof-polyfill": "~1.0.0",
+                "duplexer2": "~0.1.4",
+                "fstream": "~1.0.10",
+                "listenercount": "~1.0.1",
+                "readable-stream": "~2.1.5",
+                "setimmediate": "~1.0.4"
+            },
+            "dependencies": {
+                "bluebird": {
+                    "version": "3.4.7",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+                    "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+                    "peer": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                    "peer": true
+                },
+                "readable-stream": {
+                    "version": "2.1.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                    "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+                    "peer": true,
+                    "requires": {
+                        "buffer-shims": "^1.0.0",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
+                    }
+                }
+            }
+        },
         "upath": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -51922,6 +56295,12 @@
                     "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
                 }
             }
+        },
+        "url-join": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+            "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
+            "peer": true
         },
         "url-parse": {
             "version": "1.4.7",
@@ -52525,10 +56904,9 @@
             }
         },
         "ws": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-            "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
-            "dev": true,
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+            "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
             "requires": {}
         },
         "wtf-8": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "FCO-LOI-Service",
             "version": "0.0.1",
             "dependencies": {
+                "@aws-sdk/client-s3": "^3.48.0",
                 "@tokenizer/s3": "^0.2.0",
                 "amqplib": "^0.5.1",
                 "aws-sdk": "^2.940.0",
@@ -127,7 +128,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
             "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -137,14 +137,12 @@
         "node_modules/@aws-crypto/crc32/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/ie11-detection": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
             "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -152,14 +150,12 @@
         "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -174,14 +170,12 @@
         "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -191,14 +185,12 @@
         "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
             "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -206,14 +198,12 @@
         "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/util": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
             "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.1.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -223,14 +213,12 @@
         "node_modules/@aws-crypto/util/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/abort-controller": {
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.47.2.tgz",
             "integrity": "sha512-OpxsJ3b2KlpqTQKq6Py6JtLhA7KaAtHthH1JLLWStaFhU5/Js8nFnfPWdJIDRLpuAGyeRTbkjOEUsOkWAI5dAw==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -243,7 +231,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.47.1.tgz",
             "integrity": "sha512-D8wcAumX+q/VlX6lbYHWJqsaDBvj1BHVjJlBwLPrUBcsk0bRaJhhbhesej6DkhRX2pFhwXlHgc7CAgYhJCtc/w==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             }
@@ -252,7 +239,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.47.2.tgz",
             "integrity": "sha512-29+ZWESaFDQ9QXo7RGcUMuP89GTKo8bKlYplzNsO/B1uG17LgTgVHBapU3UBlF/EkOh1rzN5tEW+XwwstHvlXg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/util-base64-browser": "3.47.1",
                 "tslib": "^2.3.0"
@@ -262,7 +248,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.48.0.tgz",
             "integrity": "sha512-zOr7WWr9b5V3nTQnMTz+kjDpLJceI5Vmx3+mwi5a3vFDwJBvMJK0C25A9koDXtrjn8/hszAePh6+rC0oW8QJsQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -322,7 +307,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.48.0.tgz",
             "integrity": "sha512-A9f7B5k+X7bx062OQEcLHIMMIq0H1GlUqdw9xReCLd6W6vcRthbeSK5xbkM7TzHeKHE2/9qQYAy0lyKkxFE6bQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -363,7 +347,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.48.0.tgz",
             "integrity": "sha512-vOSIYCHjXB9nztZqwjIjV/jRZCfgej1YHpgqeNlfL8hPNhcrHemaoJaKHRPnhljIuHi+H5yQW7Pm4qJUFtGwKA==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -409,7 +392,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.47.2.tgz",
             "integrity": "sha512-uv9U/qDOSqyCPQ71qiwMslqRMxYyt0y0h6X0aQ67GCPq4rbbU/dn8PqnYT0VfX/9Ss+DcbTm7vOTxVKv+8XADA==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/signature-v4": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -424,7 +406,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.47.2.tgz",
             "integrity": "sha512-HQKXY8y51kpTrD7P8fZJNf4MdCdu0+NcdOc+HScrQ21oZJv3BXUwXxKiOWY95Z3jYqyFwSKs1/FFuQ1mV0wjPg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -438,7 +419,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.47.2.tgz",
             "integrity": "sha512-7fCIofgU5pdKGgbCAYQ8H7sIFluN3oebFyFy7C4eXJyNy/8QKjFHEW3NkNCh0Bkd5sLOqkwYU3nyRx0CbNkEoQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.47.2",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -454,7 +434,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.48.0.tgz",
             "integrity": "sha512-PSTfzK8V+3WVJOv+wlS4y09KYZx3iYj4Ad8LMGmGE4aqew8eRf6u2WuTmqrWwuOTxDra9PJ1ObcM5vBc+nZcYA==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -474,7 +453,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.48.0.tgz",
             "integrity": "sha512-7CrbUT7yEZvYSQNXxZWN5KUx355wD+xrYIafoEST28T7nwcIiu7l2zpBY3JPhPIPNXqryVKfNQJvKV1dP3wF4g==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -496,7 +474,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.47.2.tgz",
             "integrity": "sha512-LBuABkVt/tdSoHy8hdGVnInZx5QADhK90dEHc41+HTTP3bCSNsSBIErkZnmhAD/3AGz7m/4qkPmhJOqzFisY/g==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
@@ -512,7 +489,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.48.0.tgz",
             "integrity": "sha512-31Ill3ZW35dueXb09PpOJ4C8oKdRGypbnycAgLYvvqYlO4LOs9FyQAsw+t2+ExvE6DznM0vkeWTQI3y7HUVYCA==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/client-sso": "3.48.0",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -529,7 +505,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.47.2.tgz",
             "integrity": "sha512-biJo8zJwNk8Dwrd/mkTcu8iLuOlGbsG2Uahta4StkOUhZ733xewOZ4WISLXVLocb/PXLM1lZQgkobwugpFOQRA==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -543,7 +518,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.47.2.tgz",
             "integrity": "sha512-KRWpWBuICxIJOp5vPe2NzT387uW8Q5IpyMNf8SNmFe9a9yTrg2oIRKkbEHHRNyCRnjbDmpU3Td58V9bpmaBXGw==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-sdk/types": "3.47.1",
@@ -555,7 +529,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.47.2.tgz",
             "integrity": "sha512-dXjJ0eoNCu9P6uOzNcIL0OoXhVbdR/LPTRJCIR7NcfGCmJ4ZXeYwgYcHFTosrT/+SXAFGgsoU23dqA63TFWlMQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/eventstream-serde-universal": "3.47.2",
@@ -570,7 +543,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.47.2.tgz",
             "integrity": "sha512-LE481skmmWqoPhGyhFWqf/0eEtAFKSJqyzPZEer6yFUpejaijek4Heo6B+Y3cyDGoASuqY4Wum+9q1Z1xPn2BQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -583,7 +555,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.47.2.tgz",
             "integrity": "sha512-hrEsbDFaRr7rNJw+qgua+YhkMgSkgR/YhBe+rdI20maaJARIjLo4C8eRqAqrmlE4i2+PU4CvM/fVdL9M3HQXfQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/eventstream-serde-universal": "3.47.2",
@@ -598,7 +569,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.47.2.tgz",
             "integrity": "sha512-Zkfa2kHKNsWSAdO4atr9+JPEtcZzWuJqZHMr8MO5aXAMnKd5BA9XvzyGyhrfpr9HmnoqcbXrcx8iqDxcFEIp5g==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -612,7 +582,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.47.2.tgz",
             "integrity": "sha512-MZwwKtJwkWPm3Tzh+F3gcts13v1OuZih0slOO4GJpMxq46+lcW4DoW04lNHULJsyduXs4CziH8g65DDh0Yhq6w==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/querystring-builder": "3.47.2",
@@ -625,7 +594,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.47.2.tgz",
             "integrity": "sha512-DG8kGFUqXH+eQLLQtzTuBxBEuLHJ03w3X2Geq7aNvfwh06OOJW3FYz+FTLH2f2HxqlKOQtf3MsqpH074zKC5/A==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/chunked-blob-reader": "3.47.1",
                 "@aws-sdk/chunked-blob-reader-native": "3.47.2",
@@ -637,7 +605,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.47.2.tgz",
             "integrity": "sha512-OpUCNGvchKI1WoOCtCm36gQtECMz2P5mJoXxAHNZQ5qQ69A5Vk/DZs1V24N94M7tl1u7ZpbLsJbWFdu+P4B27g==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-buffer-from": "3.47.2",
@@ -651,7 +618,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.47.2.tgz",
             "integrity": "sha512-ModP4kZkkj4j1djuANwETAwYL1uTcXBHVcVLvy/wVDVLIcEW1TgGBgkY0rSGFE4RWDESTjhLCBKNDgvpxReSLQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -664,7 +630,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.47.2.tgz",
             "integrity": "sha512-QLIp0Gv9IbSVXru1kS92M4kF9ZgHmVP7Us8dWSu5UC7LJt6Uxhxjb+e+F0h9qY1Z3Prior12I4r5COgVO3dWxA==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -674,7 +639,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.47.1.tgz",
             "integrity": "sha512-HQMvT3dP6DCjmn87WkzYxUF9RqkvuXgKfddLEKj/tg/OgDQJv9xIPjEEry8Fd36ncbBqaBmC/z2ETZhpzHQvXA==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -686,7 +650,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.47.2.tgz",
             "integrity": "sha512-APIz8mCPscYG6gCxvC2dbrBfpM3jHwAh+VqTmGHHxxO1AAP3y5ohtdl/2MsKtEPKuyT1IX2/YoUwcOyJj65xmw==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-utf8-browser": "3.47.1",
@@ -698,7 +661,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.47.2.tgz",
             "integrity": "sha512-sjZZZ7hOR9retsblYOs4cgsVg7r1Sfuvr/aIx16XXv3TeAk7fz8JTRf5STxMM6YkGIVMbvBOHpMNvcGGgJQhZQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -713,7 +675,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.47.2.tgz",
             "integrity": "sha512-VrUrkAUS3CqI7tK3r0c0oT+1SE1L+euyq6j6Jt3XOjRMUXCkArecVkr3jEprbpVDiAkaTXEJE77iL1+98twiYA==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -729,7 +690,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.47.2.tgz",
             "integrity": "sha512-rpLtN6BczAfJnH1fpXyUOMdDFN3xrky3QZ4SULVgTLXNMOvN5zDJnjwUh/QNgEaEQhxd6lroVJSgosG3357kWg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -743,7 +703,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.47.2.tgz",
             "integrity": "sha512-sLv5q8+POzpMvp9dx/OInFr6VWJreHOGFoauYN1n7a+8dmhr9tycBLq/j+eBXI2FWwC3dXCBdrC9qs4ieSRe0Q==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-header-default": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -758,7 +717,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.47.2.tgz",
             "integrity": "sha512-fCcQaQ/ac+h8nS8d8nSrvP/scNTCdkHQ8PpNXo7nSz4a67xbxxln61T4iHOin8z0m62NlFrhtMdlQTtDqDEZVg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -772,7 +730,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.47.2.tgz",
             "integrity": "sha512-sDIGydvdO1LC7VQntTDMK+YYLRVCJAhrsCT8SxyAX0Jhu7Ek1BfRZzSZDwapL+idbMyyKsB80NpNoTWuKRrrew==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -786,7 +743,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.47.2.tgz",
             "integrity": "sha512-b6ozPYnInQB1Iv+UjLyhunTCUcw54AKtUO7Mj2QLT2GqCPDPry7ZmAC9Qtfv4Itv7HyM4VfR1roAGKZwT4zxQw==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -799,7 +755,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.47.2.tgz",
             "integrity": "sha512-Oz14cAaYmtzMYw0/ehlVLvMF4gqQS0qaYWGyyR4a3nONiwEDzxNMEQiEg7i8VgsP4usK7lfYZLXgwSmqo7uCzg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -812,7 +767,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.47.2.tgz",
             "integrity": "sha512-qgAE/+hVGXQDkqbVo+uFeb+N7mr7kBi0Oc1Fm490fm3uLQnXuyu3suIix//wxNejoLwIgKQGSLrQNgnXtuvhxw==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/service-error-classification": "3.47.2",
@@ -828,7 +782,6 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "peer": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -837,7 +790,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.47.2.tgz",
             "integrity": "sha512-KjcrHHDIn4QCh8pTRVT2u8uOnpdPYVB2p+xblwyRvJt2VLhgJbgNpRy8pOwNo2lyfbOKrmWeBk4x0NduiXle8g==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/signature-v4": "3.47.2",
@@ -856,7 +808,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.47.2.tgz",
             "integrity": "sha512-KlO4cYb4Bxf/Jg/uxlxRrFvxUR/DmjMIS+JRZNGqK4XyYA+apYZkfM0XUtMiKc491n/euluf9A0AyTxpMgixxg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-signing": "3.47.2",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -873,7 +824,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.47.2.tgz",
             "integrity": "sha512-Gjw+fkG4UvvbP5LrGW1FzUq0IJB6QIBFxStE0gbyjkKNYtcb9c0R3dIwH5CSECtelDZScytwmBKaVe8NGi6wJA==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -886,7 +836,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.47.2.tgz",
             "integrity": "sha512-r6/2gf5gwkVdI7EOa1TdYdfzOdCF3jkhjLi98c3nAxZNxZFGwoycIy7Bd6sCfOdcmk8NyVmR0APpsgD9q+a3nw==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -902,7 +851,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.47.2.tgz",
             "integrity": "sha512-dRNQJjvlg4omfhAfSYtZva4OpS/58aLO7y8l2o5sQHGPwob5OYO5zfPioi4h68UZw1fagG962hUywOkVJDJAuw==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -915,7 +863,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.47.2.tgz",
             "integrity": "sha512-9wedI1L92stvg5fs6Y3CbUXYLZIYdI3Mrdqex+ulNRuepgZNORsk+dnb8rTkf9cO3nuWRrnfKBLc/uiTcA1dww==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -927,7 +874,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.47.2.tgz",
             "integrity": "sha512-LF5gOi37lJ3tkuDSqZVKHmqYY8oTIUTEdmPVUbBQtPKsx9xfCNbMNVAP+C+7bnbt6StZIZsvtu0M144yNFXPGQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -941,7 +887,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.47.2.tgz",
             "integrity": "sha512-POdigo6ZXLRVWhmjE21Y1Q1ziPnM/c3rH0wHgzAtdx0Mfn6/9jS77QHMkZzC8MJ7lzgXVFDWM25evVZqdYrh+g==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
@@ -956,7 +901,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.47.2.tgz",
             "integrity": "sha512-X2Y+H2DBoeDnrSe5rsVc63uhext230AuG/+hIFHK2/HkyG9DiiHKNCNj2w8N4FLWEX3l8KDif3C7BqYxj9ZkDg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -972,7 +916,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.47.2.tgz",
             "integrity": "sha512-0NiVJ6+JtRC8XOvNb1ofHtsjINrinC1/fDKvl/bDtJDhehC5EcIeiDQmHFUhGsgTyD+VpmuHj7E4AlV6BchNPQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -985,7 +928,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.47.2.tgz",
             "integrity": "sha512-XAQFbSigJD0fk61nSR6y6TMv3+o1IjymltWuDmGEtoI25pisC2M3A+3/xO9YHag/41CSgt9nQ+lh1iC4UlKKJw==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -998,7 +940,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.47.2.tgz",
             "integrity": "sha512-rsckQ262jFSDVES6rOuTnSDM9XEbM57zxeBj5BtD6eCnyUD0G4FZa1xZRum4khoxfff6/eJ+i2uncKrEk1v+EQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-uri-escape": "3.47.1",
@@ -1012,7 +953,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.47.2.tgz",
             "integrity": "sha512-28BirdFhZ+Y2pUMuI9r1ATgcQyt4q3cSqqpLSy7ADGb7xHde6oA/ZfRdX/s7OVIHoAfhrjAeI+TbYjwso9F/HA==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -1025,7 +965,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.47.2.tgz",
             "integrity": "sha512-oJCJbAPYhTNguJUhD8hlD7ibWIDpkvGrhkcq89gxBcXHPl/2/kjsii0gr302IH452IJlumpVe5wOXoZeqZYjaw==",
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             }
@@ -1034,7 +973,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.47.1.tgz",
             "integrity": "sha512-f0eVOMYkT4H0gOf1B9lw65/xeTa7rT9hocVB7DbjWk8Ifv46Uvlb4ZyYOLZIBDQyFNFrD/HHvja3BkzfV0MEOA==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1046,7 +984,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.47.2.tgz",
             "integrity": "sha512-zJIhUY8LLiQldfM9wpgVw525dHbILJovyZm3xmm6Tq/t258cawNaeOvOp9w0I3ycA3gs+nKgMXdeMjLH8QLbWg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "@aws-sdk/types": "3.47.1",
@@ -1080,7 +1017,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.47.2.tgz",
             "integrity": "sha512-vCzZodWyKmLzC+N/B1GzDjKD8I5b/ILTwPHaaH7yJdncISq/3jyTMJVW7mZHbDX61a18rL/bADnIxEd524Y2hQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-stack": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -1094,7 +1030,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.1.tgz",
             "integrity": "sha512-c+lxJJLD5Bq8HkrgaIWQfK8oGH53CYpRRJizyQ5qfRo9aXp/qshUnIVcgnA8t0k7jfzcIfa0Q7jSSBw3EerEbg==",
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             }
@@ -1103,7 +1038,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.47.2.tgz",
             "integrity": "sha512-xapm+8toLY1FJmdGWl/YWCGSbbzPitiKmcg9+NP1DIyZyHjzeG5vBZ2SYejYtGOf+Qn1VKyNN2+Qs049FOsh6w==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/querystring-parser": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -1114,7 +1048,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.47.1.tgz",
             "integrity": "sha512-Q+tZjYyBeWMyPJ6+l42JXS7gt5crXywJbLDGjoLoS+Ba0JDB5zp8IMRLzGzQpTO+VnbL4ZyEEUVEihyqFbB0iw==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1126,7 +1059,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.47.1.tgz",
             "integrity": "sha512-asStae2d1xvgs3czWvvVb4JWHfY2iV8yximL4MwF+Lb8XG/b8LH3tG1E5axAFVMBcljdvRB941N7w3rug7V9ig==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             }
@@ -1135,7 +1067,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.47.2.tgz",
             "integrity": "sha512-0Oml66+9/uERV1dosecA/1tEd0zdiwI3kEobCF5w2f4gJDzUdaEoztcRwtbLcFv6yVT7XoW4evMQbtlcruypcQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.47.2",
                 "tslib": "^2.3.0"
@@ -1148,7 +1079,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.47.1.tgz",
             "integrity": "sha512-qR307MATPC+4JtN7W9sSkchfdB3O4mulLKRpk7rF6Ns6vVwhaPfJstSGe9Qa68zYZXubF9h5WnoWuJz4N0Vqdw==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             }
@@ -1157,7 +1087,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.47.1.tgz",
             "integrity": "sha512-U2K7+gi3bAQBb3WB1/trvA+4rPC2SKH9w/sRtqBwtxHNOjXjiCiF3oEYnbir7cdSfhzMH4HBYKbfkHZwTAHMfw==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1169,7 +1098,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.47.2.tgz",
             "integrity": "sha512-oLytLGiIeJEk7FcT7bdeQNv7+vvVVPuL5hyXlCjHZwoWuDxepjoDhTaIC9Isq1UyPKfSZaVpk/1nqREe4aYDHw==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "tslib": "^2.3.0"
@@ -1182,7 +1110,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.47.1.tgz",
             "integrity": "sha512-kBs+YghZaOqChxLZDTR8dw5RQxJ/qF064EjRpC+TdCegLCO2UtZ97RXBvc5mdt94OxXGjGUjDiD/eAlpjjFNXw==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1194,7 +1121,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.47.2.tgz",
             "integrity": "sha512-C0L8pfZkJyWfuvLVRcM2Ff11t2mkM4lzjNBnQKdL80wuASZWCnAi50oUKBgwbHZdOsRKGV7C4zqAuTLTRaFpCQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
                 "tslib": "^2.3.0"
@@ -1207,7 +1133,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.47.2.tgz",
             "integrity": "sha512-ojAF5k/VFbPvJoj6/G6ekVQhbFvabUBvRhRaoQjkmj8LVEahtzcNcOxhu3FmH17mXR2oxWsGwvq6VAw6V3jLBg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -1222,7 +1147,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.47.2.tgz",
             "integrity": "sha512-O35bXeahlepgPxg72XDN+5cXlbs+jZec5AH+7YYI+ldEVu6WxF0MxeQtMG4Fqpb19bpPIPz0SodHM1D1I53S5w==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/config-resolver": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -1239,7 +1163,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.47.1.tgz",
             "integrity": "sha512-9vBhp1E74s6nImK5xk7BkopQ10w6Vk8UrIinu71U7V/0PdjCEb4Jmnn++MLyim2jTT0QEGmJ6v0VjPZi9ETWaA==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1251,7 +1174,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.1.tgz",
             "integrity": "sha512-dMcBhtyJ7ZMNS8RS4UOVbkiR0gGrBWv+p1s9NLfMNXod9zaTAlMIKl9de8Xdshguvc8//J7heQV/7+HMvFEq2g==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1263,7 +1185,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.47.1.tgz",
             "integrity": "sha512-CGqm+bT07OCJSgDo48/4Fegh9tNPR3kcOMfNWZ/J6lrt+nfAnOdXx5zZB63PjKCt5zJ7LM0thOQgAeOf2WdJzQ==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1275,7 +1196,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.47.2.tgz",
             "integrity": "sha512-dstakqLW8hXRMzR/s3uLpfYbMs/qDowG/Fp123cAuln4rUODG29VNFLkMAYRnG6RQ9hf2OtXsCfFGNSm+bnJMg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.47.1",
                 "bowser": "^2.11.0",
@@ -1286,7 +1206,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.47.2.tgz",
             "integrity": "sha512-9wYkGvTrOFWb+9QjziQma+l9M0u1tmHiIdL9r4Btsc9WVMsy1Y9HUUeXacM3dLLIzCpQ5dDbjIlAZWA8Rm3ZOQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -1300,7 +1219,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.47.1.tgz",
             "integrity": "sha512-PzHEdiBhfnZbHvZ+dIlIPodDbpgrpKDYslHe9A+tH8ZfuAxxmZEqnukp7QEkFr6mBcmq3H2thcPdNT45/5pA7Q==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             }
@@ -1309,7 +1227,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.47.2.tgz",
             "integrity": "sha512-itgWlytqhbD/pRiGxX7XY7RF8k15ScV816FUlZtOKeRpAphliFT07TGWKmiZcFxEbHpi9r8A5H1FOoPmyU635Q==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.47.2",
                 "tslib": "^2.3.0"
@@ -1322,7 +1239,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.47.2.tgz",
             "integrity": "sha512-3zzOEDPRgHJ3o17Ri0vVmCKvqh9tA2lP9WbpXTjOgEAfdI/hsP2XhqJWVrlyN+wQ6FwPbuX3Jsb7lsp1OZP2bg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -1336,7 +1252,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.47.1.tgz",
             "integrity": "sha512-SPDSKG7zw7MnGFVl3uIVNBBZo4WyNg8Wu82COfD8XaH+E/XiYiHjjoPq8eIscrQb799TXudHxy5h/C7dFACMxA==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -7205,8 +7120,7 @@
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-            "peer": true
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "node_modules/boxen": {
             "version": "1.3.0",
@@ -11544,7 +11458,6 @@
             "version": "3.19.0",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
             "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
-            "peer": true,
             "bin": {
                 "xml2js": "cli.js"
             },
@@ -32166,7 +32079,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
             "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
-            "peer": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -32176,8 +32088,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "peer": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -32185,7 +32096,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
             "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
-            "peer": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -32193,8 +32103,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "peer": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -32202,7 +32111,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-            "peer": true,
             "requires": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -32217,8 +32125,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "peer": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -32226,7 +32133,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-            "peer": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -32236,8 +32142,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "peer": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -32245,7 +32150,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
             "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
-            "peer": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -32253,8 +32157,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "peer": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -32262,7 +32165,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
             "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "^3.1.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -32272,8 +32174,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "peer": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -32281,7 +32182,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.47.2.tgz",
             "integrity": "sha512-OpxsJ3b2KlpqTQKq6Py6JtLhA7KaAtHthH1JLLWStaFhU5/Js8nFnfPWdJIDRLpuAGyeRTbkjOEUsOkWAI5dAw==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32291,7 +32191,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.47.1.tgz",
             "integrity": "sha512-D8wcAumX+q/VlX6lbYHWJqsaDBvj1BHVjJlBwLPrUBcsk0bRaJhhbhesej6DkhRX2pFhwXlHgc7CAgYhJCtc/w==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32300,7 +32199,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.47.2.tgz",
             "integrity": "sha512-29+ZWESaFDQ9QXo7RGcUMuP89GTKo8bKlYplzNsO/B1uG17LgTgVHBapU3UBlF/EkOh1rzN5tEW+XwwstHvlXg==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/util-base64-browser": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32310,7 +32208,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.48.0.tgz",
             "integrity": "sha512-zOr7WWr9b5V3nTQnMTz+kjDpLJceI5Vmx3+mwi5a3vFDwJBvMJK0C25A9koDXtrjn8/hszAePh6+rC0oW8QJsQ==",
-            "peer": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -32367,7 +32264,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.48.0.tgz",
             "integrity": "sha512-A9f7B5k+X7bx062OQEcLHIMMIq0H1GlUqdw9xReCLd6W6vcRthbeSK5xbkM7TzHeKHE2/9qQYAy0lyKkxFE6bQ==",
-            "peer": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -32405,7 +32301,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.48.0.tgz",
             "integrity": "sha512-vOSIYCHjXB9nztZqwjIjV/jRZCfgej1YHpgqeNlfL8hPNhcrHemaoJaKHRPnhljIuHi+H5yQW7Pm4qJUFtGwKA==",
-            "peer": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -32448,7 +32343,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.47.2.tgz",
             "integrity": "sha512-uv9U/qDOSqyCPQ71qiwMslqRMxYyt0y0h6X0aQ67GCPq4rbbU/dn8PqnYT0VfX/9Ss+DcbTm7vOTxVKv+8XADA==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/signature-v4": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32460,7 +32354,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.47.2.tgz",
             "integrity": "sha512-HQKXY8y51kpTrD7P8fZJNf4MdCdu0+NcdOc+HScrQ21oZJv3BXUwXxKiOWY95Z3jYqyFwSKs1/FFuQ1mV0wjPg==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32471,7 +32364,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.47.2.tgz",
             "integrity": "sha512-7fCIofgU5pdKGgbCAYQ8H7sIFluN3oebFyFy7C4eXJyNy/8QKjFHEW3NkNCh0Bkd5sLOqkwYU3nyRx0CbNkEoQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.47.2",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -32484,7 +32376,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.48.0.tgz",
             "integrity": "sha512-PSTfzK8V+3WVJOv+wlS4y09KYZx3iYj4Ad8LMGmGE4aqew8eRf6u2WuTmqrWwuOTxDra9PJ1ObcM5vBc+nZcYA==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -32501,7 +32392,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.48.0.tgz",
             "integrity": "sha512-7CrbUT7yEZvYSQNXxZWN5KUx355wD+xrYIafoEST28T7nwcIiu7l2zpBY3JPhPIPNXqryVKfNQJvKV1dP3wF4g==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -32520,7 +32410,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.47.2.tgz",
             "integrity": "sha512-LBuABkVt/tdSoHy8hdGVnInZx5QADhK90dEHc41+HTTP3bCSNsSBIErkZnmhAD/3AGz7m/4qkPmhJOqzFisY/g==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
@@ -32533,7 +32422,6 @@
             "version": "3.48.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.48.0.tgz",
             "integrity": "sha512-31Ill3ZW35dueXb09PpOJ4C8oKdRGypbnycAgLYvvqYlO4LOs9FyQAsw+t2+ExvE6DznM0vkeWTQI3y7HUVYCA==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/client-sso": "3.48.0",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -32547,7 +32435,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.47.2.tgz",
             "integrity": "sha512-biJo8zJwNk8Dwrd/mkTcu8iLuOlGbsG2Uahta4StkOUhZ733xewOZ4WISLXVLocb/PXLM1lZQgkobwugpFOQRA==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32558,7 +32445,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.47.2.tgz",
             "integrity": "sha512-KRWpWBuICxIJOp5vPe2NzT387uW8Q5IpyMNf8SNmFe9a9yTrg2oIRKkbEHHRNyCRnjbDmpU3Td58V9bpmaBXGw==",
-            "peer": true,
             "requires": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-sdk/types": "3.47.1",
@@ -32570,7 +32456,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.47.2.tgz",
             "integrity": "sha512-dXjJ0eoNCu9P6uOzNcIL0OoXhVbdR/LPTRJCIR7NcfGCmJ4ZXeYwgYcHFTosrT/+SXAFGgsoU23dqA63TFWlMQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/eventstream-serde-universal": "3.47.2",
@@ -32582,7 +32467,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.47.2.tgz",
             "integrity": "sha512-LE481skmmWqoPhGyhFWqf/0eEtAFKSJqyzPZEer6yFUpejaijek4Heo6B+Y3cyDGoASuqY4Wum+9q1Z1xPn2BQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32592,7 +32476,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.47.2.tgz",
             "integrity": "sha512-hrEsbDFaRr7rNJw+qgua+YhkMgSkgR/YhBe+rdI20maaJARIjLo4C8eRqAqrmlE4i2+PU4CvM/fVdL9M3HQXfQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/eventstream-serde-universal": "3.47.2",
@@ -32604,7 +32487,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.47.2.tgz",
             "integrity": "sha512-Zkfa2kHKNsWSAdO4atr9+JPEtcZzWuJqZHMr8MO5aXAMnKd5BA9XvzyGyhrfpr9HmnoqcbXrcx8iqDxcFEIp5g==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/eventstream-marshaller": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32615,7 +32497,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.47.2.tgz",
             "integrity": "sha512-MZwwKtJwkWPm3Tzh+F3gcts13v1OuZih0slOO4GJpMxq46+lcW4DoW04lNHULJsyduXs4CziH8g65DDh0Yhq6w==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/querystring-builder": "3.47.2",
@@ -32628,7 +32509,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.47.2.tgz",
             "integrity": "sha512-DG8kGFUqXH+eQLLQtzTuBxBEuLHJ03w3X2Geq7aNvfwh06OOJW3FYz+FTLH2f2HxqlKOQtf3MsqpH074zKC5/A==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/chunked-blob-reader": "3.47.1",
                 "@aws-sdk/chunked-blob-reader-native": "3.47.2",
@@ -32640,7 +32520,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.47.2.tgz",
             "integrity": "sha512-OpUCNGvchKI1WoOCtCm36gQtECMz2P5mJoXxAHNZQ5qQ69A5Vk/DZs1V24N94M7tl1u7ZpbLsJbWFdu+P4B27g==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-buffer-from": "3.47.2",
@@ -32651,7 +32530,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.47.2.tgz",
             "integrity": "sha512-ModP4kZkkj4j1djuANwETAwYL1uTcXBHVcVLvy/wVDVLIcEW1TgGBgkY0rSGFE4RWDESTjhLCBKNDgvpxReSLQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32661,7 +32539,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.47.2.tgz",
             "integrity": "sha512-QLIp0Gv9IbSVXru1kS92M4kF9ZgHmVP7Us8dWSu5UC7LJt6Uxhxjb+e+F0h9qY1Z3Prior12I4r5COgVO3dWxA==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32671,7 +32548,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.47.1.tgz",
             "integrity": "sha512-HQMvT3dP6DCjmn87WkzYxUF9RqkvuXgKfddLEKj/tg/OgDQJv9xIPjEEry8Fd36ncbBqaBmC/z2ETZhpzHQvXA==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32680,7 +32556,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.47.2.tgz",
             "integrity": "sha512-APIz8mCPscYG6gCxvC2dbrBfpM3jHwAh+VqTmGHHxxO1AAP3y5ohtdl/2MsKtEPKuyT1IX2/YoUwcOyJj65xmw==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-utf8-browser": "3.47.1",
@@ -32692,7 +32567,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.47.2.tgz",
             "integrity": "sha512-sjZZZ7hOR9retsblYOs4cgsVg7r1Sfuvr/aIx16XXv3TeAk7fz8JTRf5STxMM6YkGIVMbvBOHpMNvcGGgJQhZQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -32704,7 +32578,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.47.2.tgz",
             "integrity": "sha512-VrUrkAUS3CqI7tK3r0c0oT+1SE1L+euyq6j6Jt3XOjRMUXCkArecVkr3jEprbpVDiAkaTXEJE77iL1+98twiYA==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32717,7 +32590,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.47.2.tgz",
             "integrity": "sha512-rpLtN6BczAfJnH1fpXyUOMdDFN3xrky3QZ4SULVgTLXNMOvN5zDJnjwUh/QNgEaEQhxd6lroVJSgosG3357kWg==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32728,7 +32600,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.47.2.tgz",
             "integrity": "sha512-sLv5q8+POzpMvp9dx/OInFr6VWJreHOGFoauYN1n7a+8dmhr9tycBLq/j+eBXI2FWwC3dXCBdrC9qs4ieSRe0Q==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/middleware-header-default": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -32740,7 +32611,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.47.2.tgz",
             "integrity": "sha512-fCcQaQ/ac+h8nS8d8nSrvP/scNTCdkHQ8PpNXo7nSz4a67xbxxln61T4iHOin8z0m62NlFrhtMdlQTtDqDEZVg==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32751,7 +32621,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.47.2.tgz",
             "integrity": "sha512-sDIGydvdO1LC7VQntTDMK+YYLRVCJAhrsCT8SxyAX0Jhu7Ek1BfRZzSZDwapL+idbMyyKsB80NpNoTWuKRrrew==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32762,7 +32631,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.47.2.tgz",
             "integrity": "sha512-b6ozPYnInQB1Iv+UjLyhunTCUcw54AKtUO7Mj2QLT2GqCPDPry7ZmAC9Qtfv4Itv7HyM4VfR1roAGKZwT4zxQw==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32772,7 +32640,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.47.2.tgz",
             "integrity": "sha512-Oz14cAaYmtzMYw0/ehlVLvMF4gqQS0qaYWGyyR4a3nONiwEDzxNMEQiEg7i8VgsP4usK7lfYZLXgwSmqo7uCzg==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32782,7 +32649,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.47.2.tgz",
             "integrity": "sha512-qgAE/+hVGXQDkqbVo+uFeb+N7mr7kBi0Oc1Fm490fm3uLQnXuyu3suIix//wxNejoLwIgKQGSLrQNgnXtuvhxw==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/service-error-classification": "3.47.2",
@@ -32794,8 +32660,7 @@
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-                    "peer": true
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
                 }
             }
         },
@@ -32803,7 +32668,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.47.2.tgz",
             "integrity": "sha512-KjcrHHDIn4QCh8pTRVT2u8uOnpdPYVB2p+xblwyRvJt2VLhgJbgNpRy8pOwNo2lyfbOKrmWeBk4x0NduiXle8g==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/signature-v4": "3.47.2",
@@ -32816,7 +32680,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.47.2.tgz",
             "integrity": "sha512-KlO4cYb4Bxf/Jg/uxlxRrFvxUR/DmjMIS+JRZNGqK4XyYA+apYZkfM0XUtMiKc491n/euluf9A0AyTxpMgixxg==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/middleware-signing": "3.47.2",
                 "@aws-sdk/property-provider": "3.47.2",
@@ -32830,7 +32693,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.47.2.tgz",
             "integrity": "sha512-Gjw+fkG4UvvbP5LrGW1FzUq0IJB6QIBFxStE0gbyjkKNYtcb9c0R3dIwH5CSECtelDZScytwmBKaVe8NGi6wJA==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32840,7 +32702,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.47.2.tgz",
             "integrity": "sha512-r6/2gf5gwkVdI7EOa1TdYdfzOdCF3jkhjLi98c3nAxZNxZFGwoycIy7Bd6sCfOdcmk8NyVmR0APpsgD9q+a3nw==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -32853,7 +32714,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.47.2.tgz",
             "integrity": "sha512-dRNQJjvlg4omfhAfSYtZva4OpS/58aLO7y8l2o5sQHGPwob5OYO5zfPioi4h68UZw1fagG962hUywOkVJDJAuw==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32863,7 +32723,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.47.2.tgz",
             "integrity": "sha512-9wedI1L92stvg5fs6Y3CbUXYLZIYdI3Mrdqex+ulNRuepgZNORsk+dnb8rTkf9cO3nuWRrnfKBLc/uiTcA1dww==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32872,7 +32731,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.47.2.tgz",
             "integrity": "sha512-LF5gOi37lJ3tkuDSqZVKHmqYY8oTIUTEdmPVUbBQtPKsx9xfCNbMNVAP+C+7bnbt6StZIZsvtu0M144yNFXPGQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -32883,7 +32741,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.47.2.tgz",
             "integrity": "sha512-POdigo6ZXLRVWhmjE21Y1Q1ziPnM/c3rH0wHgzAtdx0Mfn6/9jS77QHMkZzC8MJ7lzgXVFDWM25evVZqdYrh+g==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
@@ -32895,7 +32752,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.47.2.tgz",
             "integrity": "sha512-X2Y+H2DBoeDnrSe5rsVc63uhext230AuG/+hIFHK2/HkyG9DiiHKNCNj2w8N4FLWEX3l8KDif3C7BqYxj9ZkDg==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/abort-controller": "3.47.2",
                 "@aws-sdk/protocol-http": "3.47.2",
@@ -32908,7 +32764,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.47.2.tgz",
             "integrity": "sha512-0NiVJ6+JtRC8XOvNb1ofHtsjINrinC1/fDKvl/bDtJDhehC5EcIeiDQmHFUhGsgTyD+VpmuHj7E4AlV6BchNPQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32918,7 +32773,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.47.2.tgz",
             "integrity": "sha512-XAQFbSigJD0fk61nSR6y6TMv3+o1IjymltWuDmGEtoI25pisC2M3A+3/xO9YHag/41CSgt9nQ+lh1iC4UlKKJw==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32928,7 +32782,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.47.2.tgz",
             "integrity": "sha512-rsckQ262jFSDVES6rOuTnSDM9XEbM57zxeBj5BtD6eCnyUD0G4FZa1xZRum4khoxfff6/eJ+i2uncKrEk1v+EQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "@aws-sdk/util-uri-escape": "3.47.1",
@@ -32939,7 +32792,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.47.2.tgz",
             "integrity": "sha512-28BirdFhZ+Y2pUMuI9r1ATgcQyt4q3cSqqpLSy7ADGb7xHde6oA/ZfRdX/s7OVIHoAfhrjAeI+TbYjwso9F/HA==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "tslib": "^2.3.0"
@@ -32948,14 +32800,12 @@
         "@aws-sdk/service-error-classification": {
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.47.2.tgz",
-            "integrity": "sha512-oJCJbAPYhTNguJUhD8hlD7ibWIDpkvGrhkcq89gxBcXHPl/2/kjsii0gr302IH452IJlumpVe5wOXoZeqZYjaw==",
-            "peer": true
+            "integrity": "sha512-oJCJbAPYhTNguJUhD8hlD7ibWIDpkvGrhkcq89gxBcXHPl/2/kjsii0gr302IH452IJlumpVe5wOXoZeqZYjaw=="
         },
         "@aws-sdk/shared-ini-file-loader": {
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.47.1.tgz",
             "integrity": "sha512-f0eVOMYkT4H0gOf1B9lw65/xeTa7rT9hocVB7DbjWk8Ifv46Uvlb4ZyYOLZIBDQyFNFrD/HHvja3BkzfV0MEOA==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -32964,7 +32814,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.47.2.tgz",
             "integrity": "sha512-zJIhUY8LLiQldfM9wpgVw525dHbILJovyZm3xmm6Tq/t258cawNaeOvOp9w0I3ycA3gs+nKgMXdeMjLH8QLbWg==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "@aws-sdk/types": "3.47.1",
@@ -32992,7 +32841,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.47.2.tgz",
             "integrity": "sha512-vCzZodWyKmLzC+N/B1GzDjKD8I5b/ILTwPHaaH7yJdncISq/3jyTMJVW7mZHbDX61a18rL/bADnIxEd524Y2hQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/middleware-stack": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -33002,14 +32850,12 @@
         "@aws-sdk/types": {
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.1.tgz",
-            "integrity": "sha512-c+lxJJLD5Bq8HkrgaIWQfK8oGH53CYpRRJizyQ5qfRo9aXp/qshUnIVcgnA8t0k7jfzcIfa0Q7jSSBw3EerEbg==",
-            "peer": true
+            "integrity": "sha512-c+lxJJLD5Bq8HkrgaIWQfK8oGH53CYpRRJizyQ5qfRo9aXp/qshUnIVcgnA8t0k7jfzcIfa0Q7jSSBw3EerEbg=="
         },
         "@aws-sdk/url-parser": {
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.47.2.tgz",
             "integrity": "sha512-xapm+8toLY1FJmdGWl/YWCGSbbzPitiKmcg9+NP1DIyZyHjzeG5vBZ2SYejYtGOf+Qn1VKyNN2+Qs049FOsh6w==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/querystring-parser": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -33020,7 +32866,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.47.1.tgz",
             "integrity": "sha512-Q+tZjYyBeWMyPJ6+l42JXS7gt5crXywJbLDGjoLoS+Ba0JDB5zp8IMRLzGzQpTO+VnbL4ZyEEUVEihyqFbB0iw==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -33029,7 +32874,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.47.1.tgz",
             "integrity": "sha512-asStae2d1xvgs3czWvvVb4JWHfY2iV8yximL4MwF+Lb8XG/b8LH3tG1E5axAFVMBcljdvRB941N7w3rug7V9ig==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -33038,7 +32882,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.47.2.tgz",
             "integrity": "sha512-0Oml66+9/uERV1dosecA/1tEd0zdiwI3kEobCF5w2f4gJDzUdaEoztcRwtbLcFv6yVT7XoW4evMQbtlcruypcQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.47.2",
                 "tslib": "^2.3.0"
@@ -33048,7 +32891,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.47.1.tgz",
             "integrity": "sha512-qR307MATPC+4JtN7W9sSkchfdB3O4mulLKRpk7rF6Ns6vVwhaPfJstSGe9Qa68zYZXubF9h5WnoWuJz4N0Vqdw==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -33057,7 +32899,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.47.1.tgz",
             "integrity": "sha512-U2K7+gi3bAQBb3WB1/trvA+4rPC2SKH9w/sRtqBwtxHNOjXjiCiF3oEYnbir7cdSfhzMH4HBYKbfkHZwTAHMfw==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -33066,7 +32907,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.47.2.tgz",
             "integrity": "sha512-oLytLGiIeJEk7FcT7bdeQNv7+vvVVPuL5hyXlCjHZwoWuDxepjoDhTaIC9Isq1UyPKfSZaVpk/1nqREe4aYDHw==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.47.1",
                 "tslib": "^2.3.0"
@@ -33076,7 +32916,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.47.1.tgz",
             "integrity": "sha512-kBs+YghZaOqChxLZDTR8dw5RQxJ/qF064EjRpC+TdCegLCO2UtZ97RXBvc5mdt94OxXGjGUjDiD/eAlpjjFNXw==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -33085,7 +32924,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.47.2.tgz",
             "integrity": "sha512-C0L8pfZkJyWfuvLVRcM2Ff11t2mkM4lzjNBnQKdL80wuASZWCnAi50oUKBgwbHZdOsRKGV7C4zqAuTLTRaFpCQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/shared-ini-file-loader": "3.47.1",
                 "tslib": "^2.3.0"
@@ -33095,7 +32933,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.47.2.tgz",
             "integrity": "sha512-ojAF5k/VFbPvJoj6/G6ekVQhbFvabUBvRhRaoQjkmj8LVEahtzcNcOxhu3FmH17mXR2oxWsGwvq6VAw6V3jLBg==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -33107,7 +32944,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.47.2.tgz",
             "integrity": "sha512-O35bXeahlepgPxg72XDN+5cXlbs+jZec5AH+7YYI+ldEVu6WxF0MxeQtMG4Fqpb19bpPIPz0SodHM1D1I53S5w==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/config-resolver": "3.47.2",
                 "@aws-sdk/credential-provider-imds": "3.47.2",
@@ -33121,7 +32957,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.47.1.tgz",
             "integrity": "sha512-9vBhp1E74s6nImK5xk7BkopQ10w6Vk8UrIinu71U7V/0PdjCEb4Jmnn++MLyim2jTT0QEGmJ6v0VjPZi9ETWaA==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -33130,7 +32965,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.1.tgz",
             "integrity": "sha512-dMcBhtyJ7ZMNS8RS4UOVbkiR0gGrBWv+p1s9NLfMNXod9zaTAlMIKl9de8Xdshguvc8//J7heQV/7+HMvFEq2g==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -33139,7 +32973,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.47.1.tgz",
             "integrity": "sha512-CGqm+bT07OCJSgDo48/4Fegh9tNPR3kcOMfNWZ/J6lrt+nfAnOdXx5zZB63PjKCt5zJ7LM0thOQgAeOf2WdJzQ==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -33148,7 +32981,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.47.2.tgz",
             "integrity": "sha512-dstakqLW8hXRMzR/s3uLpfYbMs/qDowG/Fp123cAuln4rUODG29VNFLkMAYRnG6RQ9hf2OtXsCfFGNSm+bnJMg==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/types": "3.47.1",
                 "bowser": "^2.11.0",
@@ -33159,7 +32991,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.47.2.tgz",
             "integrity": "sha512-9wYkGvTrOFWb+9QjziQma+l9M0u1tmHiIdL9r4Btsc9WVMsy1Y9HUUeXacM3dLLIzCpQ5dDbjIlAZWA8Rm3ZOQ==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -33170,7 +33001,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.47.1.tgz",
             "integrity": "sha512-PzHEdiBhfnZbHvZ+dIlIPodDbpgrpKDYslHe9A+tH8ZfuAxxmZEqnukp7QEkFr6mBcmq3H2thcPdNT45/5pA7Q==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -33179,7 +33009,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.47.2.tgz",
             "integrity": "sha512-itgWlytqhbD/pRiGxX7XY7RF8k15ScV816FUlZtOKeRpAphliFT07TGWKmiZcFxEbHpi9r8A5H1FOoPmyU635Q==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.47.2",
                 "tslib": "^2.3.0"
@@ -33189,7 +33018,6 @@
             "version": "3.47.2",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.47.2.tgz",
             "integrity": "sha512-3zzOEDPRgHJ3o17Ri0vVmCKvqh9tA2lP9WbpXTjOgEAfdI/hsP2XhqJWVrlyN+wQ6FwPbuX3Jsb7lsp1OZP2bg==",
-            "peer": true,
             "requires": {
                 "@aws-sdk/abort-controller": "3.47.2",
                 "@aws-sdk/types": "3.47.1",
@@ -33200,7 +33028,6 @@
             "version": "3.47.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.47.1.tgz",
             "integrity": "sha512-SPDSKG7zw7MnGFVl3uIVNBBZo4WyNg8Wu82COfD8XaH+E/XiYiHjjoPq8eIscrQb799TXudHxy5h/C7dFACMxA==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.3.0"
             }
@@ -37788,8 +37615,7 @@
         "bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-            "peer": true
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "boxen": {
             "version": "1.3.0",
@@ -41236,8 +41062,7 @@
         "fast-xml-parser": {
             "version": "3.19.0",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-            "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
-            "peer": true
+            "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
         },
         "fastestsmallesttextencoderdecoder": {
             "version": "1.0.22",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "node": "4.x"
     },
     "dependencies": {
+        "@aws-sdk/client-s3": "^3.48.0",
         "@tokenizer/s3": "^0.2.0",
         "amqplib": "^0.5.1",
         "aws-sdk": "^2.940.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
         "test-server": "NODE_ENV=development TZ='UTC' node node_modules/mocha/bin/mocha",
         "test-report": "NODE_ENV=development TZ='UTC' node node_modules/mocha/bin/mocha --reporter mocha-junit-reporter --reporter-options outputs=true",
         "test-ui": "jest",
-        "test": "NODE_ENV=test node node_modules/mocha/bin/mocha -R xunit-file",
         "test-jenkins": "node node_modules/mocha/bin/mocha -R xunit-file",
         "coverage": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- -R tap > test.tap && istanbul report clover",
         "test-win": "node node_modules/mocha/bin/mocha --recursive -R spec",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
         "node": "4.x"
     },
     "dependencies": {
-        "@aws-sdk/client-s3": "^3.48.0",
         "@tokenizer/s3": "^0.2.0",
         "amqplib": "^0.5.1",
         "aws-sdk": "^2.940.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
         "node": "4.x"
     },
     "dependencies": {
+        "@aws-sdk/client-s3": "^3.48.0",
+        "@tokenizer/s3": "^0.2.0",
         "amqplib": "^0.5.1",
         "aws-sdk": "^2.940.0",
         "axios": "^0.24.0",

--- a/tests/env.vars
+++ b/tests/env.vars
@@ -1,0 +1,11 @@
+export APPLICATIONDATABASE='{"host": "placeholder","user": "fco_service", "password": "placeholder","database":"placeholder","port": 5432}'
+export CASEBOOKCERTIFICATE="placeholder"
+export CASEBOOKKEY="placeholder"
+export HMACKEY="placeholder"
+export LIVEVARIABLES='{"Public":true,"startPageURL":"placeholder","GOVUKURL":"placeholder","feedbackURL":"placeholder"}'
+export PAYMENT='{"paymentStartPageUrl": "placeholder", "additionalPaymentStartPageUrl": "placeholder"}'
+export STANDARDSERVICERESTRICTIONS='{"enableRestrictions":false,"maxNumOfDocumentsPerSubmission":10, "appSubmissionTimeFrameInDays":7, "maxNumOfAppSubmissionsInTimeFrame":1}'
+export USERSERVICESEQUELIZE='{"database":"FCO-LOI-User", "user":"fco_user", "password":"placeholder", "host": "placeholder", "port":5432}'
+export CUSTOMURLS='{"postcodeLookUpApiOptions" :{"uri":"placeholder","proxy":"","timeout": 5000}, "logoutUrl" : "placeholder","userServiceURL": "placeholder","notificationServiceURL": "placeholder", "applicationStatusAPIURL":"placeholder" ,"feedbackURL":"placeholder"}'
+export THESESSION='{"secret": "placeholder", "adapter": "connect-redis", "host": "placeholder", "port": 6379, "password": "placeholder", "prefix": "sess:", "key":"express.sid", "domain":"placeholder", "cookie": {"cookieMaxAge": 1800000, "timeoutWarning": 300000}, "piwikId":19}'
+export UPLOAD='{"s3_bucket": "placeholder","clamav_host": "clamav.legalisation.local", "clamav_port": "3310","clamav_enabled":"true"}'

--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -131,7 +131,7 @@ describe('uploadFilesPage', () => {
                     clamav_port: '',
                     s3_bucket: '',
                     clamav_enabled: true,
-                    clamav_debug_enabled: false
+                    clamav_debug_enabled: false,
                 },
             },
         },
@@ -231,6 +231,10 @@ describe('uploadFileHandler', () => {
         };
     });
 
+    afterEach(() => {
+        FileUploadController._multerSetup.restore();
+    });
+
     it('should remove previous error messages before uploading file', () => {
         // when
         reqStub.session.eApp.uploadMessages.fileCountError = true;
@@ -245,37 +249,38 @@ describe('uploadFileHandler', () => {
         // then
         expect(reqStub.session.eApp.uploadMessages.fileCountError).to.be.false;
         expect(reqStub.session.eApp.uploadMessages.infectedFiles).to.be.empty;
-        FileUploadController._multerSetup.restore();
     });
 
     describe('_errorChecksAfterUpload', () => {
         beforeEach(() => {
             sandbox
-            .stub(FileUploadController, '_multerSetup')
-            .callsFake(
-                () => (req, res, err) =>
-                    FileUploadController._errorChecksAfterUpload(req, res, err)
-            );
+                .stub(FileUploadController, '_multerSetup')
+                .callsFake(
+                    () => (req, res, err) =>
+                        FileUploadController._errorChecksAfterUpload(
+                            req,
+                            res,
+                            err
+                        )
+                );
             FileUploadController.uploadFileHandler(reqStub, resStub);
         });
 
-        afterEach(() => {
-            FileUploadController._multerSetup.restore();
+
+        it.only('should redirect to upload-files page after uploading a file', () => {
+            // when - before each
+
+            // then
+            expect(resStub.redirect.getCall(0).args[0]).to.equal('/upload-files');
         });
-    });
-    it('should redirect to upload-files page after uploading a file', () => {
-        // when - before each
 
-        // then
-        expect(resStub.redirect.calledWith('/upload-files')).to.be.true;
-    });
+        it('makes noFileUploadedError true in session if no files uploaded', () => {
+            // when - before each
 
-    it.only('makes noFileUploadedError true in session if no files uploaded', () => {
-        // when - before each
-
-        // then
-        expect(reqStub.session.eApp.uploadMessages.noFileUploadedError).to.be
-            .true;
+            // then
+            expect(reqStub.session.eApp.uploadMessages.noFileUploadedError).to
+                .be.true;
+        });
     });
 });
 

--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -216,6 +216,7 @@ describe('uploadFileHandler', () => {
                         error: [],
                         fileCountError: false,
                         infectedFiles: [],
+                        noFileUploadedError: false,
                     },
                 },
             },
@@ -247,19 +248,34 @@ describe('uploadFileHandler', () => {
         FileUploadController._multerSetup.restore();
     });
 
-    it('should redirect to upload-files page after uploading a file', () => {
-        // when
-        sandbox
+    describe('_errorChecksAfterUpload', () => {
+        beforeEach(() => {
+            sandbox
             .stub(FileUploadController, '_multerSetup')
             .callsFake(
                 () => (req, res, err) =>
                     FileUploadController._errorChecksAfterUpload(req, res, err)
             );
-        FileUploadController.uploadFileHandler(reqStub, resStub);
+            FileUploadController.uploadFileHandler(reqStub, resStub);
+        });
+
+        afterEach(() => {
+            FileUploadController._multerSetup.restore();
+        });
+    });
+    it('should redirect to upload-files page after uploading a file', () => {
+        // when - before each
 
         // then
         expect(resStub.redirect.calledWith('/upload-files')).to.be.true;
-        FileUploadController._multerSetup.restore();
+    });
+
+    it.only('makes noFileUploadedError true in session if no files uploaded', () => {
+        // when - before each
+
+        // then
+        expect(reqStub.session.eApp.uploadMessages.noFileUploadedError).to.be
+            .true;
     });
 });
 

--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -267,7 +267,7 @@ describe('uploadFileHandler', () => {
         });
 
 
-        it.only('should redirect to upload-files page after uploading a file', () => {
+        it('should redirect to upload-files page after uploading a file', () => {
             // when - before each
 
             // then


### PR DESCRIPTION
# Description
This ticket is here to achieve a few things
- Fix the issue where checking a documents file type then scanning causes the scan to abort if successful
- Better error handling so that if a scan is actually aborted the file is deleted and the user is informed

## First issue
To fix that the [tokenizer/S3](https://github.com/Borewit/tokenizer-s3) package was used to check the file type instead of checking file type from stream as that was causing issues. 
Tokenizer/S3 is using a [newer version of the aws sdk](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/index.html) (with different syntax) so this was updated in this PR as well but only in one file. I will create a follow-up ticket to update this everywhere.

## Second issue
There are two ways to handle errors to the user for this feature. One refers to the current page and displays the error to the user because there is something they can to do fix it, i.e. this file is not a pdf
The other one shows the following page:

<img width="930" alt="Screenshot 2022-02-01 at 15 03 14" src="https://user-images.githubusercontent.com/1377253/152135788-5d5323bb-ec11-4f23-91f7-a94fcf17baf4.png">

Because the user can't usually do anything like ClamAV is down or aborts the scan.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)