### PR TITLE
Fix issue with aria-expanded being added to all radio buttons

### DIFF
--- a/assets/js/gov_uk_scripts.js
+++ b/assets/js/gov_uk_scripts.js
@@ -60,33 +60,6 @@ function ShowHideContent() {
           }
         });
 
-      } else {
-
-        // If the data-target attribute is undefined for a radio button,
-        // hide visible data-target content for radio buttons in the same group
-
-        $radio.on('click', function () {
-
-          // Select radio buttons in the same group
-          $("input.govuk-radios__input[name=" + self.escapeElementName($radioGroupName) + "]").each(function () {
-            var groupDataTarget = $(this).parent('div').attr('data-target');
-            var $groupDataTarget = $('#' + groupDataTarget);
-
-            // Hide toggled content
-            //user basic details screen, uses element id to find and hide, used to work with new govuk-frontend radios
-            if(self.escapeElementName($radioGroupName)==="has_email") {
-              $("#emails").hide();
-            }
-            else{
-              $groupDataTarget.hide();
-            }
-
-            // Set aria-expanded and aria-hidden for hidden content
-            $(this).attr('aria-expanded', 'false');
-            $groupDataTarget.attr('aria-hidden', 'true');
-          });
-
-        });
       }
 
     });

--- a/views/eApostilles/applicationType.ejs
+++ b/views/eApostilles/applicationType.ejs
@@ -33,7 +33,7 @@
             action="/handle-service-choice"
             method="post"
         >
-            <div class="govuk-radios<%if (error_report) { %> govuk-form-group--error<%}%>" data-module="govuk-radios">
+            <div class="govuk-radios<%if (error_report) { %> govuk-form-group--error<%}%>">
                 <%if (error_report) { %>
                     <span id="no-service-chosen-error" class="govuk-error-message">
                         <span class="govuk-visually-hidden">Error:</span> You must select a service type.

--- a/views/eApostilles/applicationType.ejs
+++ b/views/eApostilles/applicationType.ejs
@@ -33,7 +33,7 @@
             action="/handle-service-choice"
             method="post"
         >
-            <div class="govuk-radios<%if (error_report) { %> govuk-form-group--error<%}%>">
+            <div class="govuk-radios<%if (error_report) { %> govuk-form-group--error<%}%>" data-module="govuk-radios">
                 <%if (error_report) { %>
                     <span id="no-service-chosen-error" class="govuk-error-message">
                         <span class="govuk-visually-hidden">Error:</span> You must select a service type.


### PR DESCRIPTION
# Description
https://consular.atlassian.net/browse/EIA-357
The aira-expanded attribute was being added automatically to all radio buttons but it should only be added to radio 

buttons that have expanded content like so:
<img width="596" alt="Screenshot 2022-02-02 at 17 10 12" src="https://user-images.githubusercontent.com/1377253/152202704-f09186b1-d222-4478-b2a7-a50ca9ff029f.png">

This was causing a11y issues so needed to be fixed:
![893ea8db-4aae-47ae-acef-68fd16b02d5f](https://user-images.githubusercontent.com/1377253/152202801-5322c6f9-c6c6-4fff-b1c8-91a5748f656f.png)

_NOTE: This looks like an issue that was caused by existing some legacy govuk scripts which means it's there even on the existing service. I don't know how this wasn't caught before 🤷_ 
