### PR TITLE
fix: add back links to eligibility exit page...

### DIFF
--- a/views/eApostilles/openEApp.ejs
+++ b/views/eApostilles/openEApp.ejs
@@ -83,7 +83,7 @@
             </p>
             <p>
                 You will have 21 days from when the documents have been successfully legalised to download them before they
-                are deleted for security reasons.
+                are deleted for data privacy reasons.
             </p>
         <% } %>
 
@@ -130,7 +130,7 @@
         <dl class="govuk-summary-list govuk-summary-list--no-border">
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key govuk-summary-list__key--wide">
-                    Original cost
+                    Total paid
                 </dt>
                 <dd class="govuk-summary-list__value">
                     <%= originalCost %>

--- a/views/eApostilles/useStandardService.ejs
+++ b/views/eApostilles/useStandardService.ejs
@@ -1,5 +1,12 @@
 <% pageTitle="You cannot use this service" %>
 <% const question = req.params.question; %>
+<% const backLocation = {
+   "apostille-acceptance": "apostille-accepted-in-destination",
+   "apostille-eligible": "documents-eligible-for-service",
+   "apostille-digitally-signed": "pdfs-digitally-signed",
+} %>
+
+<a href="/eligibility/<%= backLocation[question] %>" class="back-to-previous govuk-link">Back</a>
 
 <div class="inner_header no-user-signed-in">
     <%- partial('../partials/inner-header')%>


### PR DESCRIPTION
# Description
This PR fixe a few small tings that Khurram noticed was missing. The main one being the lack of a back link on the exit page for the eligibility questions.

![9f972d04-5c1f-4dfb-83c9-30aa4e5f7020](https://user-images.githubusercontent.com/1377253/153642436-6140a4a2-ca60-4f63-8af9-dcdff06a4134.png)

The next being updating some incorrect copy
![1eb3ca61-b3f7-48bf-88d4-a6ded9584073](https://user-images.githubusercontent.com/1377253/153642609-1a01c3f1-e89d-400b-961e-7e6a04ec3bab.png)

