### PR TITLE
Replace request files with session data to fix race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ uploads
 test-results.xml
 a11y-test-results.xml
 cypress/screenshots
+cypress/browsers/*/*

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -78,13 +78,7 @@ const FileUploadController = {
             return;
         }
 
-        const largeFileRemoved = removeFilesIfLarge(req);
-
-        if (largeFileRemoved) {
-            FileUploadController._redirectToUploadPage(res);
-            sails.log.error('Large file removed.');
-            return;
-        }
+       removeFilesIfLarge(req);
 
         if (err) {
             const fileLimitExceeded = err.code === MULTER_FILE_COUNT_ERR_CODE;

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -7,7 +7,7 @@ const deleteFileFromStorage = require('../helpers/deleteFileFromStorage');
 const {
     virusScan,
     checkTypeSizeAndDuplication,
-    removeLargeFiles,
+    removeFilesIfLarge,
     connectToClamAV,
     checkFileType,
     UserAdressableError,
@@ -21,6 +21,7 @@ const inDevEnvironment = process.env.NODE_ENV === 'development';
 const FileUploadController = {
     async uploadFilesPage(req, res) {
         const connectedToClamAV = await connectToClamAV(req);
+        // @ts-ignore
         const userData = HelperService.getUserData(req, res);
 
         if (!connectedToClamAV) {
@@ -74,9 +75,16 @@ const FileUploadController = {
             req.session.eApp.uploadMessages.noFileUploadedError = true;
             sails.log.error('No files were uploaded.');
             FileUploadController._redirectToUploadPage(res);
+            return;
         }
 
-        removeLargeFiles(req);
+        const largeFileRemoved = removeFilesIfLarge(req);
+
+        if (largeFileRemoved) {
+            FileUploadController._redirectToUploadPage(res);
+            sails.log.error('Large file removed.');
+            return;
+        }
 
         if (err) {
             const fileLimitExceeded = err.code === MULTER_FILE_COUNT_ERR_CODE;

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -323,10 +323,11 @@ function addErrorsToSession(req, file, errors) {
     }
 }
 
-function removeLargeFiles(req) {
+function removeFilesIfLarge(req) {
     const UPLOAD_LIMIT_TO_MB =
         req._sails.config.upload.file_upload_size_limit * 1_000_000;
     const MAX_BYTES_PER_FILE = UPLOAD_LIMIT_TO_MB;
+    let filesRemoved = false;
 
     for (const file of req.files) {
         if (file.size > MAX_BYTES_PER_FILE) {
@@ -338,8 +339,11 @@ function removeLargeFiles(req) {
             ];
             addErrorsToSession(req, file, error);
             removeSingleFile(req, file);
+            filesRemoved = true;
         }
     }
+
+    return filesRemoved;
 }
 
 function formatFileSizeMb(bytes, decimalPlaces = 1) {
@@ -355,7 +359,7 @@ class UserAdressableError extends Error {
 
 module.exports = {
     checkTypeSizeAndDuplication,
-    removeLargeFiles,
+    removeFilesIfLarge,
     virusScan,
     connectToClamAV,
     checkFileType,

--- a/api/helpers/uploadedFileErrorChecks.js
+++ b/api/helpers/uploadedFileErrorChecks.js
@@ -63,10 +63,13 @@ function initialiseClamScan(req) {
 async function checkFileType(req) {
     try {
         sails.log.info('Checking file type...');
-        for (const file of req.files) {
+        const { uploadedFileData } = req.session.eApp;
+
+        for (const fileFromSession of uploadedFileData) {
+
             inDevEnvironment
-                ? await checkLocalFileType(file, req)
-                : await checkS3FileType(file, req);
+                ? await checkLocalFileType(fileFromSession, req)
+                : await checkS3FileType(fileFromSession, req);
         }
     } catch (err) {
         if (err.message === `Error: ${UPLOAD_ERROR.incorrectFileType}`) {
@@ -78,7 +81,7 @@ async function checkFileType(req) {
 
 async function checkLocalFileType(file, req) {
     try {
-        const absoluteFilePath = resolve('uploads', file.filename);
+        const absoluteFilePath = resolve('uploads', file.storageName);
         const fileType = await FileType.fromFile(absoluteFilePath);
 
         addErrorToSessionIfNotPDF(file, req, fileType);
@@ -93,11 +96,10 @@ async function checkLocalFileType(file, req) {
  */
 async function checkS3FileType(file, req) {
     try {
-        const storageName = getStorageNameFromSession(file, req);
         const s3Bucket = req._sails.config.upload.s3_bucket;
         const s3Tokenizer = await makeTokenizer(s3, {
             Bucket: s3Bucket,
-            Key: storageName,
+            Key: file.storageName,
         });
         const fileType = await FileType.fromTokenizer(s3Tokenizer);
 
@@ -113,13 +115,16 @@ async function virusScan(req) {
 
     try {
         clamscan = await initialiseClamScan(req);
+        const { uploadedFileData } = req.session.eApp;
+
         if (!clamscan) {
             throw new Error('Not connected to clamAV');
         }
-        for (const file of req.files) {
+        for (const fileFromSession of uploadedFileData) {
+
             inDevEnvironment
-                ? await scanFilesLocally(file, req)
-                : await scanStreamOfS3File(file, req);
+                ? await scanFilesLocally(fileFromSession, req)
+                : await scanStreamOfS3File(fileFromSession, req);
         }
     } catch (err) {
         if (err.message === `Error: ${UPLOAD_ERROR.fileInfected}`) {
@@ -131,7 +136,7 @@ async function virusScan(req) {
 
 async function scanFilesLocally(file, req) {
     try {
-        const absoluteFilePath = resolve('uploads', file.filename);
+        const absoluteFilePath = resolve('uploads', file.storageName);
         const scanResults = await clamscan.isInfected(absoluteFilePath);
 
         scanResponses(scanResults, file, req);
@@ -143,10 +148,9 @@ async function scanFilesLocally(file, req) {
 
 async function scanStreamOfS3File(file, req) {
     try {
-        const storageName = getStorageNameFromSession(file, req);
         const s3Bucket = req._sails.config.upload.s3_bucket;
         const scanResults = await clamscan.scanStream(
-            await getS3FileStream(storageName, s3Bucket)
+            await getS3FileStream(file.storageName, s3Bucket)
         );
 
         await addUnsubmittedTag(file, req);
@@ -172,51 +176,42 @@ async function getS3FileStream(storageName, s3Bucket) {
 
 function addErrorToSessionIfNotPDF(file, req, fileType) {
     if (!fileType || fileType.mime !== 'application/pdf') {
-        addErrorsToSession(req, file, [
+        addErrorsToSession(req, file.filename, [
             'The file is in the wrong file type. Only PDF files are allowed.',
         ]);
         throw new Error(UPLOAD_ERROR.incorrectFileType);
     }
 }
 
-function getStorageNameFromSession(file, req) {
-    const { uploadedFileData } = req.session.eApp;
-    const fileWithStorageNameFound = uploadedFileData.find(
-        (uploadedFile) => uploadedFile.filename === file.originalname
-    );
-    return fileWithStorageNameFound.storageName;
-}
-
 async function addUnsubmittedTag(file, req) {
     try {
-        const fileStorageName = getStorageNameFromSession(file, req);
         const fileBelongsToUnsubmittedApplication = {
             Key: 'app_status',
             Value: 'UNSUBMITTED',
         };
         const params = {
             Bucket: req._sails.config.upload.s3_bucket,
-            Key: fileStorageName,
+            Key: file.storageName,
             Tagging: {
                 TagSet: [fileBelongsToUnsubmittedApplication],
             },
         };
 
         await s3.send(new PutObjectTaggingCommand(params));
-        sails.log.info(`Only UNSUBMITTED tag added to ${fileStorageName}`);
+        sails.log.info(`Only UNSUBMITTED tag added to ${file.storageName}`);
     } catch (err) {
         throw new Error(`addUnsubmittedTag ${err}`);
     }
 }
 
 function scanResponses(scanResults, file, req = null, forS3 = false) {
-    const { isInfected, viruses } = scanResults;
+    const { isInfected } = scanResults;
     if (isInfected) {
         addInfectedFilenameToSessionErrors(req, file);
         throw new Error(UPLOAD_ERROR.fileInfected);
     }
 
-    sails.log.info(`${file.originalname} is not infected.`);
+    sails.log.info(`${file.filename} is not infected.`);
 
     if (forS3) {
         addCleanAndUnsubmittedTagsToFile(file, req);
@@ -228,12 +223,14 @@ function removeSingleFile(req, file) {
     const { s3_bucket: s3BucketName } = req._sails.config.upload;
 
     const updatedSession = uploadedFileData.filter((uploadedFile) => {
-        const fileToDeleteInSession =
-            file.originalname === uploadedFile.filename;
+        const fileDataFromRequest = file.hasOwnProperty('originalname');
+        const fileName = fileDataFromRequest ? file.originalname : file.filename;
+        const fileToDeleteInSession = fileName === uploadedFile.filename;
+
         if (fileToDeleteInSession) {
             deleteFileFromStorage(uploadedFile, s3BucketName);
         }
-        return uploadedFile.filename !== file.originalname;
+        return uploadedFile.filename !== fileName;
     });
     req.session.eApp.uploadedFileData = updatedSession;
 }
@@ -241,13 +238,12 @@ function removeSingleFile(req, file) {
 function addInfectedFilenameToSessionErrors(req, file) {
     req.session.eApp.uploadMessages.infectedFiles = [
         ...req.session.eApp.uploadMessages.infectedFiles,
-        file.originalname,
+        file.filename,
     ];
 }
 
 async function addCleanAndUnsubmittedTagsToFile(file, req) {
     try {
-        const uploadedStorageName = getStorageNameFromSession(file, req);
         const fileNotInfected = {
             Key: 'av-status',
             Value: 'CLEAN',
@@ -258,7 +254,7 @@ async function addCleanAndUnsubmittedTagsToFile(file, req) {
         };
         const params = {
             Bucket: req._sails.config.upload.s3_bucket,
-            Key: uploadedStorageName,
+            Key: file.storageName,
             Tagging: {
                 TagSet: [fileNotInfected, restoreUnsubmittedTag],
             },
@@ -267,7 +263,7 @@ async function addCleanAndUnsubmittedTagsToFile(file, req) {
         await s3.send(new PutObjectTaggingCommand(params));
 
         sails.log.info(
-            `Both CLEAN and UNSUBMITTED tags added to ${uploadedStorageName}`
+            `Both CLEAN and UNSUBMITTED tags added to ${file.storageName}`
         );
     } catch (err) {
         throw new Error(`addCleanAndUnsubmittedTagsToFile ${err}`);
@@ -295,20 +291,20 @@ function checkTypeSizeAndDuplication(req, file, cb) {
     }
 
     if (errors.length > 0) {
-        addErrorsToSession(req, file, errors);
+        addErrorsToSession(req, file.originalname, errors);
         preventFileUpload();
     } else {
         allowFileUplaod();
     }
 }
 
-function addErrorsToSession(req, file, errors) {
+function addErrorsToSession(req, fileName, errors) {
     const fileNamesWithErrors = req.session.eApp.uploadMessages.errors.map(
         (error) => error.hasOwnProperty('filename') && error.filename
     );
-    if (fileNamesWithErrors.includes(file.originalname)) {
-        fileNamesWithErrors.forEach((fileName, idx) => {
-            if (fileName === file.originalname) {
+    if (fileNamesWithErrors.includes(fileName)) {
+        fileNamesWithErrors.forEach((fileNameFromSession, idx) => {
+            if (fileNameFromSession === fileName) {
                 req.session.eApp.uploadMessages.errors[idx].errors = [
                     ...req.session.eApp.uploadMessages.errors[idx].errors,
                     ...errors,
@@ -317,7 +313,7 @@ function addErrorsToSession(req, file, errors) {
         });
     } else {
         req.session.eApp.uploadMessages.errors.push({
-            filename: file.originalname,
+            filename: fileName,
             errors,
         });
     }
@@ -326,24 +322,19 @@ function addErrorsToSession(req, file, errors) {
 function removeFilesIfLarge(req) {
     const UPLOAD_LIMIT_TO_MB =
         req._sails.config.upload.file_upload_size_limit * 1_000_000;
-    const MAX_BYTES_PER_FILE = UPLOAD_LIMIT_TO_MB;
-    let filesRemoved = false;
 
     for (const file of req.files) {
-        if (file.size > MAX_BYTES_PER_FILE) {
+        if (file.size > UPLOAD_LIMIT_TO_MB) {
             const error = [
                 `The file is too big. Each file you upload must be a maximum of ${formatFileSizeMb(
-                    MAX_BYTES_PER_FILE,
+                    UPLOAD_LIMIT_TO_MB,
                     0
                 )}`,
             ];
-            addErrorsToSession(req, file, error);
+            addErrorsToSession(req, file.originalname, error);
             removeSingleFile(req, file);
-            filesRemoved = true;
         }
     }
-
-    return filesRemoved;
 }
 
 function formatFileSizeMb(bytes, decimalPlaces = 1) {

--- a/tests/specs/helpers/uploadedFileErrorChecks.test.js
+++ b/tests/specs/helpers/uploadedFileErrorChecks.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const fs = require('fs');
 const {
     checkTypeSizeAndDuplication,
-    removeLargeFiles,
+    removeFilesIfLarge,
 } = require('../../../api/helpers/uploadedFileErrorChecks');
 
 const sandbox = sinon.sandbox.create();
@@ -137,7 +137,7 @@ describe('checkTypeSizeAndDuplication', () => {
                     size: 210_000_000,
                 },
             });
-            removeLargeFiles(reqStub);
+            removeFilesIfLarge(reqStub);
 
             // then
             expect(reqStub.session.eApp.uploadedFileData.length).to.equal(0);
@@ -159,7 +159,7 @@ describe('checkTypeSizeAndDuplication', () => {
                     size: 10_000_000,
                 },
             });
-            removeLargeFiles(reqStub);
+            removeFilesIfLarge(reqStub);
 
             // then
             const expectedUploadedFileData = [


### PR DESCRIPTION
# Description

There was a bug with the app which, I'm surprised wasn't caught before where, if a large file is uploaded then automatically deleted by the code, the file type check expects it to be there even though it as been deleted.

I believe this happens because the file type check happens before the file is actually deleted:

<img width="1501" alt="Screenshot 2022-03-01 at 18 01 15" src="https://user-images.githubusercontent.com/1377253/156236547-cd60aa3a-47b6-40a0-8d75-9eff0fca4881.png">

To fix this I've changed the code to check for files from the session data instead of the request data (req.files) because the session data updates a lot faster, since it's not waiting for an actual file to delete.

Open to suggestions on how to make this better 👍 

## Actually...

Now that I've had some time to think about this I'm not sure if it's a race condition or just my lack of understanding in how `req.files` works. 

I do have a deleteFileHandler function which works but I don't know if the site requires a full page refresh for that to work 🤷 

Happy to explain this PR in details on request.