### PR TITLE
chore: add more checks for accessiblity

### DIFF
--- a/cypress/integration/a11y.spec.js
+++ b/cypress/integration/a11y.spec.js
@@ -87,7 +87,7 @@ describe('Check accessiblity', () => {
                 '3 - Have the PDFs been notarised and digitally signed by a notary?',
             ];
 
-            for (const page of eligibilityPages) {
+            for (const [index, page] of eligibilityPages.entries()) {
                 checkA11y(page);
 
                 clickContinueBtn();
@@ -100,6 +100,9 @@ describe('Check accessiblity', () => {
                 }).click();
 
                 findByLabelText('Yes').check();
+
+                if (index === 2) findByTestId('prepare-pdf').click();
+
                 checkA11y(`${page}- Radio Check`);
                 clickContinueBtn();
             }

--- a/cypress/integration/a11y.spec.js
+++ b/cypress/integration/a11y.spec.js
@@ -87,7 +87,7 @@ describe('Check accessiblity', () => {
                 '3 - Have the PDFs been notarised and digitally signed by a notary?',
             ];
 
-            for (const [index, page] of eligibilityPages.entries()) {
+            eligibilityPages.forEach((page, index) => {
                 checkA11y(page);
 
                 clickContinueBtn();
@@ -105,7 +105,7 @@ describe('Check accessiblity', () => {
 
                 checkA11y(`${page}- Radio Check`);
                 clickContinueBtn();
-            }
+            });
         }
 
         it('eApp eligibility questions', () => {

--- a/cypress/integration/a11y.spec.js
+++ b/cypress/integration/a11y.spec.js
@@ -80,6 +80,31 @@ describe('Check accessiblity', () => {
             findByRole('button', { name: 'Sign in' }).click();
         });
 
+        function eligibilityPages() {
+            const eligibilityPages = [
+                '1 - Is the e-Apostille accepted in the destination country?',
+                '2 - Check if the documents are eligible for the e-Apostille service',
+                '3 - Have the PDFs been notarised and digitally signed by a notary?',
+            ];
+
+            for (const page of eligibilityPages) {
+                checkA11y(page);
+
+                clickContinueBtn();
+                checkA11y(`${page}- Error`);
+
+                checkRadioAndClickContinue('No');
+                checkA11y(`${page}- Exit Page`);
+                findByRole('link', {
+                    name: 'Back',
+                }).click();
+
+                findByLabelText('Yes').check();
+                checkA11y(`${page}- Radio Check`);
+                clickContinueBtn();
+            }
+        }
+
         it('eApp eligibility questions', () => {
             clickContinueBtn();
             checkA11y('[Error] Which service would you like?');
@@ -88,32 +113,12 @@ describe('Check accessiblity', () => {
             checkA11y('Select radio option and check a11y');
 
             checkRadioAndClickContinue('e-Apostille service');
-            checkA11y(
-                '1 - Is the e-Apostille accepted in the destination country?'
-            );
 
-            checkRadioAndClickContinue('Yes');
-            checkA11y(
-                '2 - Check if the documents are eligible for the e-Apostille service'
-            );
+            eligibilityPages();
 
-            checkRadioAndClickContinue('Yes');
-            checkA11y(
-                '3 - Have the PDFs been notarised and digitally signed by a notary?'
-            );
-
-            checkRadioAndClickContinue('Yes');
             checkA11y(
                 'Get the documents legalised using the e-Apostille service'
             );
-
-            go('back');
-            checkRadioAndClickContinue('No');
-            checkA11y('You cannot use this service');
-
-            go('back');
-            checkRadioAndClickContinue('Yes');
-            clickContinueBtn();
 
             visit('/upload-files');
             checkA11y('eApp file upload');

--- a/cypress/integration/a11y.spec.js
+++ b/cypress/integration/a11y.spec.js
@@ -11,6 +11,12 @@ const {
     wait,
 } = cy;
 
+const eligibilityPages = [
+    '1 - Is the e-Apostille accepted in the destination country?',
+    '2 - Check if the documents are eligible for the e-Apostille service',
+    '3 - Have the PDFs been notarised and digitally signed by a notary?',
+];
+
 describe('Check accessiblity', () => {
     function checkA11y(logMsg) {
         if (logMsg) cy.log(logMsg);
@@ -80,14 +86,18 @@ describe('Check accessiblity', () => {
             findByRole('button', { name: 'Sign in' }).click();
         });
 
-        function eligibilityPages() {
-            const eligibilityPages = [
-                '1 - Is the e-Apostille accepted in the destination country?',
-                '2 - Check if the documents are eligible for the e-Apostille service',
-                '3 - Have the PDFs been notarised and digitally signed by a notary?',
-            ];
+        it('eApp eligibility questions', () => {
+            clickContinueBtn();
+            checkA11y('[Error] Which service would you like?');
 
-            eligibilityPages.forEach((page, index) => {
+            findByLabelText('e-Apostille service').check();
+            checkA11y('Select radio option and check a11y');
+
+            checkRadioAndClickContinue('e-Apostille service');
+
+            for (let i = 0; i < eligibilityPages.length; i++) {
+                const page = eligibilityPages[i];
+
                 checkA11y(page);
 
                 clickContinueBtn();
@@ -101,23 +111,11 @@ describe('Check accessiblity', () => {
 
                 findByLabelText('Yes').check();
 
-                if (index === 2) findByTestId('prepare-pdf').click();
+                if (i === 2) findByTestId('prepare-pdf').click();
 
                 checkA11y(`${page}- Radio Check`);
                 clickContinueBtn();
-            });
-        }
-
-        it('eApp eligibility questions', () => {
-            clickContinueBtn();
-            checkA11y('[Error] Which service would you like?');
-
-            findByLabelText('e-Apostille service').check();
-            checkA11y('Select radio option and check a11y');
-
-            checkRadioAndClickContinue('e-Apostille service');
-
-            eligibilityPages();
+            }
 
             checkA11y(
                 'Get the documents legalised using the e-Apostille service'

--- a/cypress/integration/a11y.spec.js
+++ b/cypress/integration/a11y.spec.js
@@ -95,27 +95,55 @@ describe('Check accessiblity', () => {
 
             checkRadioAndClickContinue('e-Apostille service');
 
-            for (let i = 0; i < eligibilityPages.length; i++) {
-                const page = eligibilityPages[i];
+            checkA11y('1 - Is the e-Apostille accepted in the destination country?');
 
-                checkA11y(page);
+            clickContinueBtn();
+            checkA11y('1 - Is the e-Apostille accepted in the destination country? - Error');
 
-                clickContinueBtn();
-                checkA11y(`${page}- Error`);
+            checkRadioAndClickContinue('No');
+            checkA11y('1 - Is the e-Apostille accepted in the destination country? - Exit Page');
+            findByRole('link', {
+                name: 'Back',
+            }).click();
 
-                checkRadioAndClickContinue('No');
-                checkA11y(`${page}- Exit Page`);
-                findByRole('link', {
-                    name: 'Back',
-                }).click();
+            findByLabelText('Yes').check();
 
-                findByLabelText('Yes').check();
+            checkA11y('1 - Is the e-Apostille accepted in the destination country? - Radio Check');
+            clickContinueBtn();
 
-                if (i === 2) findByTestId('prepare-pdf').click();
+            checkA11y('2 - Check if the documents are eligible for the e-Apostille service');
 
-                checkA11y(`${page}- Radio Check`);
-                clickContinueBtn();
-            }
+            clickContinueBtn();
+            checkA11y('2 - Check if the documents are eligible for the e-Apostille service - Error');
+
+            checkRadioAndClickContinue('No');
+            checkA11y('2 - Check if the documents are eligible for the e-Apostille service - Exit Page');
+            findByRole('link', {
+                name: 'Back',
+            }).click();
+
+            findByLabelText('Yes').check();
+
+            checkA11y('2 - Check if the documents are eligible for the e-Apostille service - Radio Check');
+            clickContinueBtn();
+
+            checkA11y('3 - Have the PDFs been notarised and digitally signed by a notary?');
+
+            clickContinueBtn();
+            checkA11y('3 - Have the PDFs been notarised and digitally signed by a notary? - Error');
+
+            checkRadioAndClickContinue('No');
+            checkA11y('3 - Have the PDFs been notarised and digitally signed by a notary? - Exit Page');
+            findByRole('link', {
+                name: 'Back',
+            }).click();
+
+            findByLabelText('Yes').check();
+
+            findByTestId('prepare-pdf').click();
+
+            checkA11y('3 - Have the PDFs been notarised and digitally signed by a notary? - Radio Check');
+            clickContinueBtn();
 
             checkA11y(
                 'Get the documents legalised using the e-Apostille service'

--- a/views/eApostilles/eligibilityQuestionThree.ejs
+++ b/views/eApostilles/eligibilityQuestionThree.ejs
@@ -30,8 +30,8 @@
             a practicing notary public or solicitor.
         </p>
 
-        <details class="govuk-details" data-module="govuk-details" data-testid="prepare-pdf">
-            <summary class="govuk-details__summary">
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary" data-testid="prepare-pdf">
                 <span class="govuk-details__summary-text">
                     How to prepare the PDF
                 </span>

--- a/views/eApostilles/eligibilityQuestionThree.ejs
+++ b/views/eApostilles/eligibilityQuestionThree.ejs
@@ -30,7 +30,7 @@
             a practicing notary public or solicitor.
         </p>
 
-        <details class="govuk-details" data-module="govuk-details">
+        <details class="govuk-details" data-module="govuk-details" data-testid="prepare-pdf">
             <summary class="govuk-details__summary">
                 <span class="govuk-details__summary-text">
                     How to prepare the PDF


### PR DESCRIPTION
# Description

https://consular.atlassian.net/browse/EIA-385

This ticket is to address a few things about the accessibility tests raised by Khurram. 

These are all focused around the 3 eligibility pages in the eApp flow:

* Checking the accessibility on errors specific to the three eligibility questions
* Checking accessibility after a radio button has been selected
* Checking the accessibility of the exit pages, when someone selects 'No' the presses 'Continue'

<img width="944" alt="Screenshot 2022-03-15 at 17 12 57" src="https://user-images.githubusercontent.com/1377253/158434121-f1964c06-2752-4363-b3ff-ff40887db427.png">

<img width="1090" alt="Screenshot 2022-03-15 at 17 13 02" src="https://user-images.githubusercontent.com/1377253/158434203-f2553f96-0204-4c4f-8110-c9e102be689c.png">

<img width="890" alt="Screenshot 2022-03-15 at 17 13 09" src="https://user-images.githubusercontent.com/1377253/158434239-941404c3-230d-4cba-8d3d-c3f0080707f8.png">


