### PR TITLE
Start e-Apostille application after sign-in

### DIFF
--- a/api/controllers/ApplicationTypeController.js
+++ b/api/controllers/ApplicationTypeController.js
@@ -50,7 +50,6 @@ module.exports = {
     serviceSelectorPage(req, res) {
         // clear down eligibility checker selected documents
         req.session.search_history =[];
-        req.session.continueEAppFlow = true; // delete this
         //reset the selected documents
         req.session.selectedDocuments = {
             totalDocCount: 0,

--- a/api/controllers/ApplicationTypeController.js
+++ b/api/controllers/ApplicationTypeController.js
@@ -50,6 +50,7 @@ module.exports = {
     serviceSelectorPage(req, res) {
         // clear down eligibility checker selected documents
         req.session.search_history =[];
+        req.session.continueEAppFlow = true; // delete this
         //reset the selected documents
         req.session.selectedDocuments = {
             totalDocCount: 0,
@@ -156,7 +157,6 @@ module.exports = {
 
     req.session.appSubmittedStatus = false;
     req.session.selectedDocs = [];
-    req.session.continueEAppFlow = false;
     req.session.selectedDocsCount = [];
     req.session.searchTerm = '';
     if(req.query.from){

--- a/api/controllers/ApplicationTypeController.js
+++ b/api/controllers/ApplicationTypeController.js
@@ -19,6 +19,7 @@ module.exports = {
     start: function (req, res) {
         req.session.appSubmittedStatus = false;
         req.session.selectedDocs = [];
+        req.session.continueEAppFlow = false;
         req.session.selectedDocsCount = [];
         req.session.eApp = {
           s3FolderName: '',

--- a/api/controllers/ApplicationTypeController.js
+++ b/api/controllers/ApplicationTypeController.js
@@ -164,6 +164,7 @@ module.exports = {
 
     req.session.appSubmittedStatus = false;
     req.session.selectedDocs = [];
+    req.session.continueEAppFlow = false;
     req.session.selectedDocsCount = [];
     req.session.searchTerm = '';
     if(req.query.from){

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -36,7 +36,7 @@ module.exports = {
                         }
 
                         // second speficically if you've some to the sign in page after registering
-                        if (req.session.continueEAppFlow || req.query.name !== 'premiumCheck') {
+                        if (req.session.continueEAppFlow || req.query.name !== 'continueEApp') {
                             return res.redirect('/eapp-start-page');
                         }
                         /**

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -35,7 +35,7 @@ module.exports = {
                             return res.redirect('/dashboard');
                         }
 
-                        if (req.query.name === 'continueEApp') {
+                        if (req.session.continueEAppFlow) {
                             return res.redirect('/eapp-start-page');
                         }
                         /**

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -35,10 +35,10 @@ module.exports = {
                             return res.redirect('/dashboard');
                         }
 
-                        // second speficically if you've some to the sign in page after registering
-                        if (req.session.continueEAppFlow || req.query.name !== 'continueEApp') {
+                        if (req.session.continueEAppFlow) {
                             return res.redirect('/eapp-start-page');
                         }
+
                         /**
                          * Redirect user back to page from where they came,
                          * currently only the service selector page

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -35,7 +35,8 @@ module.exports = {
                             return res.redirect('/dashboard');
                         }
 
-                        if (req.session.continueEAppFlow) {
+                        // second speficically if you've some to the sign in page after registering
+                        if (req.session.continueEAppFlow || req.query.name !== 'premiumCheck') {
                             return res.redirect('/eapp-start-page');
                         }
                         /**

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -35,6 +35,9 @@ module.exports = {
                             return res.redirect('/dashboard');
                         }
 
+                        if (req.query.name === 'continueEApp') {
+                            return res.redirect('/eapp-start-page');
+                        }
                         /**
                          * Redirect user back to page from where they came,
                          * currently only the service selector page

--- a/views/applicationForms/applicationType.ejs
+++ b/views/applicationForms/applicationType.ejs
@@ -8,7 +8,7 @@
     <% }else{%>
         <div class="inner-header-content">
             <span class="email-logout-text">
-                 <a  href="<%= userServiceURL%>/sign-in?next=continueEApp&from=start" class="govuk-link" id="sign-in-link" >Sign in</a>
+                 <a  href="<%= userServiceURL%>/sign-in?next=serviceSelector&from=start" class="govuk-link" id="sign-in-link" >Sign in</a>
             </span>
 
         </div>
@@ -41,7 +41,7 @@
             </ul>
 
        <%if(!user_data.loggedIn){%>
-        <p>If you're a regular customer you can <a href="<%= userServiceURL%>/register?next=continueEApp&from=start" class="govuk-link">create an account</a> (optional).</p>
+        <p>If you're a regular customer you can <a href="<%= userServiceURL%>/register?next=serviceSelector&from=start" class="govuk-link">create an account</a> (optional).</p>
        <%}%>
 
         <a class="govuk-button govuk-button--secondary" id="standard-service" href="/new-application?app_type_group=1">Start a standard application</a>
@@ -58,7 +58,7 @@
             </ul>
 
             <%if(!user_data.loggedIn && !user_data.user.premiumEnabled){%>
-                <p>To use the premium service you need to <a href="<%= userServiceURL%>/register?next=continueEApp&from=start" class="create-account-link govuk-link">create an account</a>. You'll be asked to provide company details.</p>
+                <p>To use the premium service you need to <a href="<%= userServiceURL%>/register?next=serviceSelector&from=start" class="create-account-link govuk-link">create an account</a>. You'll be asked to provide company details.</p>
             <%}%>
             <a class="govuk-button govuk-button--secondary" id="premium-service" href="/new-application?app_type_group=2">Start a premium application</a>
 

--- a/views/applicationForms/applicationType.ejs
+++ b/views/applicationForms/applicationType.ejs
@@ -8,7 +8,7 @@
     <% }else{%>
         <div class="inner-header-content">
             <span class="email-logout-text">
-                 <a  href="<%= userServiceURL%>/sign-in?next=serviceSelector&from=start" class="govuk-link" id="sign-in-link" >Sign in</a>
+                 <a  href="<%= userServiceURL%>/sign-in?next=continueEApp&from=start" class="govuk-link" id="sign-in-link" >Sign in</a>
             </span>
 
         </div>

--- a/views/applicationForms/applicationType.ejs
+++ b/views/applicationForms/applicationType.ejs
@@ -41,7 +41,7 @@
             </ul>
 
        <%if(!user_data.loggedIn){%>
-        <p>If you're a regular customer you can <a href="<%= userServiceURL%>/register?next=serviceSelector&from=start" class="govuk-link">create an account</a> (optional).</p>
+        <p>If you're a regular customer you can <a href="<%= userServiceURL%>/register?next=continueEApp&from=start" class="govuk-link">create an account</a> (optional).</p>
        <%}%>
 
         <a class="govuk-button govuk-button--secondary" id="standard-service" href="/new-application?app_type_group=1">Start a standard application</a>
@@ -58,7 +58,7 @@
             </ul>
 
             <%if(!user_data.loggedIn && !user_data.user.premiumEnabled){%>
-                <p>To use the premium service you need to <a href="<%= userServiceURL%>/register?next=serviceSelector&from=start" class="create-account-link govuk-link">create an account</a>. You'll be asked to provide company details.</p>
+                <p>To use the premium service you need to <a href="<%= userServiceURL%>/register?next=continueEApp&from=start" class="create-account-link govuk-link">create an account</a>. You'll be asked to provide company details.</p>
             <%}%>
             <a class="govuk-button govuk-button--secondary" id="premium-service" href="/new-application?app_type_group=2">Start a premium application</a>
 


### PR DESCRIPTION
# Description

This PR enables a user to start the eApp process, sign-in, then continue from where they left off.

This is achieved by the combination of code changes on two repositories, this one, and the [loi-user-service](https://github.com/UKForeignOffice/loi-user-service/pull/131). By enabling a query param that from this project, that triggers a session change in the user service.

Since both projects share the same Redis session DB, they can both read and make changes. The user is redirected to the relevant page based on a boolean in the session.

**Steps**
- User starts process
- Chooses eApp on service selection screen
- Passes all eligibility questions then is asked to sign in or create an account
- The sign in link will contain a query param called `next` which will be `continueEApp`
- This will trigger `continueEAppFlow` to be true in the session
- Once the user is signed in they are redirected to the document upload page instead of the service selection page


https://user-images.githubusercontent.com/1377253/161954207-d7cd2a14-d5a6-4094-bf34-f2477bc91304.mp4


The video above has a different flow from the steps outlined above because the change in flow has not been merged into the demo branch yet. These PRs in question( [EIA-426](https://github.com/UKForeignOffice/loi-application-service/pull/357) and [EIA-432](https://github.com/UKForeignOffice/loi-application-service/pull/359)), are still in review.

