### PR TITLE
Skip payment confirmation page for eApp only

### DIFF
--- a/api/controllers/CheckUploadedDocumentsController.js
+++ b/api/controllers/CheckUploadedDocumentsController.js
@@ -37,7 +37,7 @@ const CheckUploadedDocumentsController = {
         const { appId, eApp, payment_reference: paymentRef } = req.session;
         const documentCount = eApp.uploadedFileData.length;
         const totalPrice = documentCount * req._sails.config.upload.cost_per_document;
-        const redirectUrl = req._sails.config.payment.paymentStartPageUrl;
+        const redirectUrl = `${req._sails.config.payment.paymentStartPageUrl}?skipConfirmation=true`;
         const params = {
             appId,
             totalPrice,

--- a/tests/specs/controllers/CheckUploadedDocuments.test.js
+++ b/tests/specs/controllers/CheckUploadedDocuments.test.js
@@ -103,7 +103,7 @@ describe('CheckUploadedDocumentsController', () => {
                 totalPrice: 60,
                 documentCount: 2,
                 paymentRef: 'FCO-LOI-REF-162',
-                redirectUrl: 'stub_payment_url',
+                redirectUrl: 'stub_payment_url?skipConfirmation=true',
             };
 
             // then
@@ -278,7 +278,7 @@ describe('CheckUploadedDocumentsController', () => {
             // then
             assertWhenPromisesResolved(
                 () =>
-                    expect(resStub.redirect.calledWith(307, 'stub_payment_url'))
+                    expect(resStub.redirect.calledWith(307, 'stub_payment_url?skipConfirmation=true'))
                         .to.be.true
             );
         });


### PR DESCRIPTION
# Description

https://consular.atlassian.net/browse/EIA-456

The purpose of this PR is to skip the payment confirmation page for the eApp flow only

This PR is closely linked to [this one on the payment repo](https://github.com/UKForeignOffice/loi-payment-service/pull/77).