### PR TITLE
EIA-476 Investigate why adding eApp application is not showing or showing twice on the dashboard

### DIFF
--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -27,7 +27,7 @@ const POST_UPLOAD_ERROR_MESSAGES = {
 };
 
 const FileUploadController = {
-    setupMulterMIddleware() {
+    setupMulterMiddleware() {
         const multerOptions = {
             storage: uploadFileToStorage(s3BucketName),
             fileFilter: checkTypeAndDuplication,

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -97,19 +97,19 @@ const FileUploadController = {
             if (!appId) throw new Error('No application id found in session');
 
             const userId = req.session.user.id || req.session.accunt.user_id;
-            if (!userId) throw new Error('No user_id found in session');
+            if (!userId) throw new Error('No user id found in session');
 
-            const currentApplication = await Application.findOne({
+            const currentApplicationFromDB = await Application.findOne({
                 where: {
                     application_id: appId,
                 },
             });
             const appHasPreSignedInUserId =
-                currentApplication.dataValues.user_id === PRE_SIGNED_IN_USER_ID;
+                currentApplicationFromDB.dataValues.user_id === PRE_SIGNED_IN_USER_ID;
 
             if (!appHasPreSignedInUserId) return;
 
-            currentApplication.update({
+            currentApplicationFromDB.update({
                 user_id: userId,
             });
 

--- a/config/http.js
+++ b/config/http.js
@@ -30,7 +30,7 @@ module.exports.http = {
 
 
     fileMiddleware: (function () {
-      return require('../api/controllers/FileUploadController').setupMulterMIddleware()
+      return require('../api/controllers/FileUploadController').setupMulterMiddleware()
     })(),
 
 

--- a/config/http.js
+++ b/config/http.js
@@ -30,7 +30,7 @@ module.exports.http = {
 
 
     fileMiddleware: (function () {
-      return require('../api/controllers/FileUploadController').multerSetup()
+      return require('../api/controllers/FileUploadController').setupMulterMIddleware()
     })(),
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,4 @@
 - [How file upload works](how-file-upload-works.md)
 - [Scanning uploading files w/ Clam AV](clam-av.md)
 - [Tables for eApp](e-app-tables.md)
+- [Pre-sign in flow for eApp](eApp-pre-sign-in.md)

--- a/docs/eApp-pre-sign-in.md
+++ b/docs/eApp-pre-sign-in.md
@@ -1,0 +1,40 @@
+# Pre-sign in flow for eApp
+
+As you've probably noticed, it is possible to start the process for an eApp before signing in, but later you are required to create an account or sign in before continuing.
+
+This is how this particular feature works.
+
+User:
+1. visits start page and presses green 'START NOW'
+2. selects service from service select page
+3. after this a nrw row is created in the Applications table with a few key bits of information:
+```js
+// ApplicationTyoeController.js
+{
+    serviceType: selectedServiceType,
+    unique_app_id: uniqueApplicationId,
+    all_info_correct: '-1',
+    user_id: 0,
+    submitted: 'draft',
+    company_name: 'N/A',
+    feedback_consent: 0,
+    doc_reside_EU: 0,
+    residency: 0,
+}
+```
+4. the numerical id from this row (which is incremented on each new entry) is set as the **appId** and placed in the session
+5. the **appType** is also set here and stored in the session.
+
+These two bits of information (appId & appType) and necessary to complete any applicaiton in the service.
+
+<br />
+
+## user_id set AGAIN after login for eApp only
+
+One key thing about the eApp flow is that since the user_id is set to 0 before the user signs, there is no way to identiy that the application belongs to that user which means it will never show up in their dashboard.
+
+To solve this, the user_id is set again in the database after the user signs in.
+
+This takes place on the upload pdf page `FileUploadController._addSignedInIdToApplication(req, res)`.
+
+This way the current application can be assosiated with a user.

--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -137,8 +137,12 @@ describe('uploadFilesPage', () => {
             },
         },
         session: {
+            appId: 123,
             eApp: {
                 uploadFileData: []
+            },
+            user: {
+                id: 456
             }
         },
         flash: () => [],
@@ -181,6 +185,8 @@ describe('uploadFilesPage', () => {
             .stub(HelperService, 'getUserData')
             .callsFake(() => testUserData);
         sandbox.stub(NodeClam.prototype, 'init').resolves();
+        sandbox.stub(FileUploadController, '_addSignedInIdToApplication').callsFake(() =>null);
+
         await FileUploadController.uploadFilesPage(reqStub, resStub);
 
         // then


### PR DESCRIPTION
# Description

https://consular.atlassian.net/browse/EIA-476
The purpose of this PR is to update the user_id value in the database after the user has logged in.

There is a good explanation of what is going on here:
https://github.com/UKForeignOffice/loi-application-service/blob/e2a0c04c69068e627bb657192712fe7a689d3d8b/docs/eApp-pre-sign-in.md

But if you want the TL:DR version, basically eApp has a feature where you can start the process before signing in but you have to sign in eventually, (on the document upload page).

If a user hasn't signed in they get a user_id of 0 in the database. After they've signed in they get a number like 821 or something in the session, but this isn't added to the db, therefore the application they've started will never show up in their dashboard after they complete it.

This aims to fix that by re-writing the user_id in the DB

I hope that made sense. As usually, feel free to ask questions in slack or as a comment here 👍 