### PR TITLE
EIA-479 Re-ordering application list removes the application list footer

### DIFF
--- a/api/controllers/DashboardController.js
+++ b/api/controllers/DashboardController.js
@@ -213,7 +213,6 @@ const DashboardController = {
 
             // For each element in the database results array, add the application reference status
             // if one exists.
-
             for (const result of results) {
                 const uniqueAppId = result.unique_app_id;
                 const appStatus = appRef[uniqueAppId];
@@ -308,9 +307,10 @@ const DashboardController = {
 
         if (req.query.ajax) {
             view = 'partials/dashboardResults.ejs';
-            pageAttributes.layout = null;
+            pageAttributes.layout = null; // prevents parent layout from being added to partial
         }
 
+        console.log(view, 'view')
         return res.view(view, pageAttributes);
     },
 
@@ -333,7 +333,7 @@ const DashboardController = {
             paginationMessage =
                 'Showing ' +
                 (offset + 1) +
-                ' &ndash; ' +
+                ' – ' +
                 pageUpperLimit +
                 ' of ' +
                 resultCount +

--- a/tests/specs/controllers/Dashboard.test.js
+++ b/tests/specs/controllers/Dashboard.test.js
@@ -188,7 +188,7 @@ describe('DashboardController:', () => {
         const expectedResult = {
             totalPages: 2,
             paginationMessage:
-                'Showing 1 &ndash; 20 of 35 applications submitted in the last 60 days',
+                'Showing 1 – 20 of 35 applications submitted in the last 60 days',
         };
         expect(paginationAndPageTotal).to.deep.equal(expectedResult);
     });

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -46,9 +46,6 @@
                             <h1 class="heading-medium" style="margin-top: 0">Application history</h1>
                             <div id="dashboard-results">
                                 <%- partial ('partials/dashboardResults.ejs')%>
-                                <div>
-                                <%- partial ('partials/dashboardPagination.ejs', {paginationMessage, totalPages, currentPage, searchCriteria, sortOrder})%>
-                            </div>
                             </div>
                         </div>
                         <%}%>

--- a/views/partials/dashboardResults.ejs
+++ b/views/partials/dashboardResults.ejs
@@ -108,3 +108,6 @@
         <% } %>
     </tbody>
 </table>
+<div>
+    <%- partial ('./dashboardPagination.ejs', {paginationMessage, totalPages, currentPage, searchCriteria, sortOrder})%>
+</div>


### PR DESCRIPTION
# Dashboard
https://consular.atlassian.net/browse/EIA-476

The purpose of this PR is to fix an issue where reordering data on the application dashboard hides the pagination at the bottom.

![bdd895eb-a138-4e8b-a81e-d0de057e3e19](https://user-images.githubusercontent.com/1377253/166732950-fe7d9e92-1cfd-4ccf-b944-a2562c542b77.png)

The reason this happened was because reordering the application triggered only a partial page to render instead of the whole dashboard, so to fix it the pagination just needed to be added to the partial.


