### PR TITLE
Fix/EIA 501 - Issue with uploading more than 50 files freezing page

### DIFF
--- a/api/controllers/CheckUploadedDocumentsController.js
+++ b/api/controllers/CheckUploadedDocumentsController.js
@@ -8,6 +8,10 @@ const addUserDataToDB = require('../helper/addUserDataToDB.js');
 
 const CheckUploadedDocumentsController = {
     async renderPage(req, res) {
+
+        if (HelperService.maxFileLimitExceeded(req))
+            return res.serverError('maxFileLimitExceeded');
+
         const userData = HelperService.getUserData(req, res);
         const { uploadedFileData } = req.session.eApp;
         const totalDocuments = uploadedFileData.length;

--- a/api/controllers/EAppReferenceController.js
+++ b/api/controllers/EAppReferenceController.js
@@ -1,5 +1,5 @@
 const sails = require('sails');
-const HelperService = require("../services/HelperService");
+const HelperService = require('../services/HelperService');
 
 const MAX_CHAR_LENGTH = 30;
 
@@ -12,6 +12,9 @@ const EAppReferenceController = {
             return res.forbidden();
         }
 
+        if (HelperService.maxFileLimitExceeded(req))
+            return res.serverError('maxFileLimitExceeded');
+
         return res.view('eApostilles/additionalReference.ejs', {
             user_data: userData,
             userRef: req.session.eApp.userRef,
@@ -19,7 +22,6 @@ const EAppReferenceController = {
             inputError: false,
         });
     },
-
 
     addReferenceToSession(req, res) {
         const userRef = req.body['user-reference'];

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -1,10 +1,8 @@
 // @ts-check
 const multer = require('multer');
 const sails = require('sails');
-const uploadVariables = require('../../config/environment-variables').upload;
+const { s3_bucket: s3BucketName, max_files_per_application: maxFiles } = require('../../config/environment-variables').upload;
 const Application = require('../models/index').Application;
-const { s3_bucket: s3BucketName, max_files_per_application: maxFiles } =
-    uploadVariables;
 const uploadFileToStorage = require('../helper/uploadFileToStorage');
 const deleteFileFromStorage = require('../helper/deleteFileFromStorage');
 const HelperService = require('../services/HelperService');

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -1,7 +1,7 @@
 // @ts-check
 const multer = require('multer');
 const sails = require('sails');
-const { s3_bucket: s3BucketName, max_files_per_application: maxFiles } = require('../../config/environment-variables').upload;
+const { s3_bucket: s3BucketName, max_files_per_application: maxFileLimit } = require('../../config/environment-variables').upload;
 const Application = require('../models/index').Application;
 const uploadFileToStorage = require('../helper/uploadFileToStorage');
 const deleteFileFromStorage = require('../helper/deleteFileFromStorage');
@@ -21,7 +21,7 @@ const inDevEnvironment = process.env.NODE_ENV === 'development';
 
 const POST_UPLOAD_ERROR_MESSAGES = {
     noFileUploadedError: 'No files have been selected',
-    fileCountError: `You can upload a maximum of ${maxFiles} files`,
+    fileCountError: `You can upload a maximum of ${maxFileLimit} files`,
 };
 
 const FileUploadController = {
@@ -61,7 +61,7 @@ const FileUploadController = {
                 return res.forbidden();
             }
 
-            FileUploadController._maxFileCheck(req);
+            FileUploadController._maxFileLimitCheck(req);
 
             await FileUploadController._addSignedInIdToApplication(req, res);
 
@@ -76,7 +76,7 @@ const FileUploadController = {
 
             return res.view('eApostilles/uploadFiles.ejs', {
                 user_data: userData,
-                maxFiles,
+                maxFileLimit,
                 backLink,
                 messages: {
                     displayFilenameErrors,
@@ -90,10 +90,10 @@ const FileUploadController = {
         }
     },
 
-    _maxFileCheck(req) {
+    _maxFileLimitCheck(req) {
         const totalFilesUploaded = req.session.eApp.uploadedFileData.length;
 
-        if (totalFilesUploaded > maxFiles) {
+        if (totalFilesUploaded > maxFileLimit) {
             req.flash('genericErrors', [
                 POST_UPLOAD_ERROR_MESSAGES.fileCountError,
             ]);
@@ -152,7 +152,7 @@ const FileUploadController = {
 
         removeFilesIfLarge(req);
 
-        FileUploadController._maxFileCheck(req);
+        FileUploadController._maxFileLimitCheck(req);
 
         if (err) {
             sails.log.error(err);

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -1,7 +1,8 @@
 // @ts-check
 const multer = require('multer');
 const sails = require('sails');
-const { s3_bucket: s3BucketName, max_files_per_application: maxFileLimit } = require('../../config/environment-variables').upload;
+const { s3_bucket: s3BucketName, max_files_per_application: maxFileLimit } =
+    require('../../config/environment-variables').upload;
 const Application = require('../models/index').Application;
 const uploadFileToStorage = require('../helper/uploadFileToStorage');
 const deleteFileFromStorage = require('../helper/deleteFileFromStorage');
@@ -37,8 +38,7 @@ const FileUploadController = {
     async uploadFilesPage(req, res) {
         try {
             const noUploadFileDataExistsInSession =
-                !req.session.hasOwnProperty('eApp') ||
-                !req.session.eApp.hasOwnProperty('uploadedFileData');
+                !req.session?.eApp?.uploadedFileData;
             if (noUploadFileDataExistsInSession) {
                 req.session.eApp = {
                     ...req.session.eApp,
@@ -95,6 +95,7 @@ const FileUploadController = {
 
     _maxFileLimitCheck(req) {
         const totalFilesUploaded = req.session.eApp.uploadedFileData.length;
+        const maxFileLimit = req._sails.config.upload.max_files_per_application;
 
         if (totalFilesUploaded > maxFileLimit) {
             req.flash('genericErrors', [
@@ -119,7 +120,8 @@ const FileUploadController = {
                 },
             });
             const appHasPreSignedInUserId =
-                currentApplicationFromDB.dataValues.user_id === PRE_SIGNED_IN_USER_ID;
+                currentApplicationFromDB.dataValues.user_id ===
+                PRE_SIGNED_IN_USER_ID;
 
             if (!appHasPreSignedInUserId) return;
 

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -95,7 +95,6 @@ const FileUploadController = {
 
     _maxFileLimitCheck(req) {
         const totalFilesUploaded = req.session.eApp.uploadedFileData.length;
-        const maxFileLimit = req._sails.config.upload.max_files_per_application;
 
         if (totalFilesUploaded > maxFileLimit) {
             req.flash('genericErrors', [

--- a/api/controllers/FileUploadController.js
+++ b/api/controllers/FileUploadController.js
@@ -94,14 +94,10 @@ const FileUploadController = {
     },
 
     _maxFileLimitCheck(req) {
-        const totalFilesUploaded = req.session.eApp.uploadedFileData.length;
+        if (!HelperService.maxFileLimitExceeded(req)) return;
 
-        if (totalFilesUploaded > maxFileLimit) {
-            req.flash('genericErrors', [
-                POST_UPLOAD_ERROR_MESSAGES.fileCountError,
-            ]);
-            sails.log.error('maxFileLimitExceeded');
-        }
+        req.flash('genericErrors', [POST_UPLOAD_ERROR_MESSAGES.fileCountError]);
+        sails.log.error('maxFileLimitExceeded');
     },
 
     async _addSignedInIdToApplication(req, res) {

--- a/api/services/HelperService.js
+++ b/api/services/HelperService.js
@@ -853,7 +853,7 @@ var HelperService ={
     maxFileLimitExceeded(req) {
         if (!req) return false;
 
-        const totalFilesUploaded = req.session.eApp?.uploadedFileData?.length || 0;
+        const totalFilesUploaded = req.session.eApp?.uploadedFileData?.length ?? 0;
         const maxFileLimit = req._sails?.config?.upload.max_files_per_application ?? 50;
 
         return totalFilesUploaded > maxFileLimit;

--- a/api/services/HelperService.js
+++ b/api/services/HelperService.js
@@ -849,6 +849,15 @@ var HelperService ={
             currency: 'GBP',
         }).format(number);
     },
+
+    maxFileLimitExceeded(req) {
+        if (!req) return false;
+
+        const totalFilesUploaded = req.session.eApp.uploadedFileData.length;
+        const maxFileLimit = req._sails.config.upload.max_files_per_application;
+
+        return totalFilesUploaded > maxFileLimit;
+    }
 };
 
 module.exports = HelperService;

--- a/api/services/HelperService.js
+++ b/api/services/HelperService.js
@@ -853,8 +853,8 @@ var HelperService ={
     maxFileLimitExceeded(req) {
         if (!req) return false;
 
-        const totalFilesUploaded = req.session.eApp.uploadedFileData.length;
-        const maxFileLimit = req._sails.config.upload.max_files_per_application;
+        const totalFilesUploaded = req.session.eApp.uploadedFileData.length ?? 0;
+        const maxFileLimit = req._sails.config.upload.max_files_per_application ?? 50;
 
         return totalFilesUploaded > maxFileLimit;
     }

--- a/api/services/HelperService.js
+++ b/api/services/HelperService.js
@@ -853,8 +853,8 @@ var HelperService ={
     maxFileLimitExceeded(req) {
         if (!req) return false;
 
-        const totalFilesUploaded = req.session.eApp.uploadedFileData.length ?? 0;
-        const maxFileLimit = req._sails.config.upload.max_files_per_application ?? 50;
+        const totalFilesUploaded = req.session.eApp?.uploadedFileData?.length || 0;
+        const maxFileLimit = req._sails?.config?.upload.max_files_per_application ?? 50;
 
         return totalFilesUploaded > maxFileLimit;
     }

--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -20,9 +20,18 @@ const FileType = require('file-type');
 
 const sandbox = sinon.sandbox.create();
 
-function assertWhenPromisesResolved(assertion) {
-    setTimeout(assertion);
-}
+const testFileUploadedData = [
+    {
+        fieldname: 'documents',
+        originalname: 'test_upload.pdf',
+        encoding: '7bit',
+        mimetype: 'application/pdf',
+        destination: '/test/location',
+        filename: 'be3ad2f823a54812991839c3e856ec0a_test_upload.pdf',
+        path: '/test/location/be3ad2f823a54812991839c3e856ec0a_terst_upload.pdf',
+        size: 470685,
+    },
+];
 
 // Tests are timing out
 describe.skip('FileUploadController', function () {
@@ -137,33 +146,34 @@ describe.skip('FileUploadController', function () {
 
 describe('uploadFilesPage', () => {
     let resStub = {};
-
-    const reqStub = {
-        _sails: {
-            config: {
-                upload: {
-                    clamav_host: '',
-                    clamav_port: '',
-                    s3_bucket: '',
-                    clamav_enabled: true,
-                    clamav_debug_enabled: false,
-                },
-            },
-        },
-        files: [],
-        session: {
-            appId: 123,
-            eApp: {
-                uploadFileData: [],
-            },
-            user: {
-                id: 456,
-            },
-        },
-        flash: sandbox.spy(),
-    };
+    let reqStub = {};
 
     beforeEach(() => {
+        reqStub = {
+            _sails: {
+                config: {
+                    upload: {
+                        clamav_host: '',
+                        clamav_port: '',
+                        s3_bucket: '',
+                        clamav_enabled: true,
+                        clamav_debug_enabled: false,
+                    },
+                },
+            },
+            files: [],
+            session: {
+                appId: 123,
+                eApp: {
+                    uploadFileData: [],
+                },
+                user: {
+                    id: 456,
+                },
+            },
+            flash: sandbox.spy(),
+        };
+
         resStub = {
             forbidden: sandbox.spy(),
             view: sandbox.spy(),
@@ -237,6 +247,7 @@ describe('uploadFilesPage', () => {
         expect(sails.log.error.firstCall.args[0]).to.equal(errorMsg);
     });
 
+    // Read docs/eApp-pre-sign-in.md for more info
     it('updates user_id in the Applicaiton table if it is set to 0', async () => {
         // when
         let applicationRowData = {
@@ -291,18 +302,6 @@ describe('uploadFileHandler', () => {
         serverError: sandbox.spy(),
     };
 
-    const testFileUploadedData = [
-        {
-            fieldname: 'documents',
-            originalname: 'test_upload.pdf',
-            encoding: '7bit',
-            mimetype: 'application/pdf',
-            destination: '/test/location',
-            filename: 'be3ad2f823a54812991839c3e856ec0a_test_upload.pdf',
-            path: '/test/location/be3ad2f823a54812991839c3e856ec0a_terst_upload.pdf',
-            size: 470685,
-        },
-    ];
     beforeEach(() => {
         reqStub = {
             session: {
@@ -523,6 +522,10 @@ describe('deleteFileHandler', () => {
         );
     });
 });
+
+function assertWhenPromisesResolved(assertion) {
+    setTimeout(assertion);
+}
 
 function createOverLimitFileData() {
     const overMaxFileLimit = Number(maxFileLimit) + 1;

--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -247,6 +247,10 @@ describe('uploadFilesPage', () => {
         // then
         expect(applicationRowData.user_id).to.equal(456);
     });
+
+    it('shows an error if max files exceeded on page load', () => {
+
+    });
 });
 
 describe('uploadFileHandler', () => {
@@ -307,6 +311,10 @@ describe('uploadFileHandler', () => {
         expect(reqStub.flash.getCall(0).args[1]).to.deep.equal([
             'No files have been selected',
         ]);
+    });
+
+    it('shows an error if max files exceeded on document upload', () => {
+
     });
 });
 

--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -8,7 +8,7 @@ const sinon = require('sinon');
 const FileUploadController = require('../../../api/controllers/FileUploadController');
 const HelperService = require('../../../api/services/HelperService');
 const Application = require('../../../api/models/index').Application;
-const { max_files_per_application: maxFiles } = require('../../../config/environment-variables').upload;
+const { max_files_per_application: maxFileLimit } = require('../../../config/environment-variables').upload;
 
 const sandbox = sinon.sandbox.create();
 
@@ -198,7 +198,7 @@ describe('uploadFilesPage', () => {
         );
         expect(resStub.view.getCall(0).args[1]).to.deep.equal({
             user_data: testUserData,
-            maxFiles: maxFiles,
+            maxFileLimit,
             backLink: '/eapp-start-page',
             messages: {
                 displayFilenameErrors: [],

--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -8,6 +8,7 @@ const sinon = require('sinon');
 const FileUploadController = require('../../../api/controllers/FileUploadController');
 const HelperService = require('../../../api/services/HelperService');
 const Application = require('../../../api/models/index').Application;
+const { max_files_per_application: maxFiles } = require('../../config/environment-variables').upload;
 
 const sandbox = sinon.sandbox.create();
 
@@ -181,7 +182,6 @@ describe('uploadFilesPage', () => {
             loggedIn: true,
             user: 'test_data',
         };
-        const maxFiles = '50';
         sandbox
             .stub(HelperService, 'getUserData')
             .callsFake(() => testUserData);

--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -8,7 +8,7 @@ const sinon = require('sinon');
 const FileUploadController = require('../../../api/controllers/FileUploadController');
 const HelperService = require('../../../api/services/HelperService');
 const Application = require('../../../api/models/index').Application;
-const { max_files_per_application: maxFiles } = require('../../config/environment-variables').upload;
+const { max_files_per_application: maxFiles } = require('../../../config/environment-variables').upload;
 
 const sandbox = sinon.sandbox.create();
 

--- a/views/eApostilles/uploadFiles.ejs
+++ b/views/eApostilles/uploadFiles.ejs
@@ -144,7 +144,7 @@
             </div>
         <% } %>
         <div>
-            <% if (uploadedFileData.length > 0 && uploadedFileData.length <= maxFiles) { %>
+            <% if (uploadedFileData.length > 0 && uploadedFileData.length <= maxFileLimit) { %>
                 <a href="/additional-reference" class="govuk-button" draggable="false" role="button">
                     Continue
                 </a>


### PR DESCRIPTION
# Description

https://consular.atlassian.net/browse/EIA-501

The purpose of this ticket is to address a bug where the site would freeze when more than 50 files were uploaded. 50 files is the file upload limit but that can be changed in the .env config.

The reason for the freeze was that the page was not being refreshed after the error was logged. Since this is a server-side rendered site, the page needs to refresh for the user to see an update. The error was created for the user to see, but the page was not refreshing. This should be fixed now.

## Also...

I noticed it's possible to upload more than the file limit, then navigate using the address bar to the summary page and complete the application.

Ideally a user would delete the files they didn't want until they got to 50 or below and then proceed, but they could hack it. 

I've added a fix which shows a server error if they progress and exceed the file limit, so they'll have to go back and fix that.

### As usual...
Happy to answer any questions and if you want screenshots and stuff, please let me know 🙏