### PR TITLE
Fix/EIA - 504 payment receipt filename

### DIFF
--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -12,6 +12,8 @@ const expect = chai.expect;
 const FileUploadController = require('../../../api/controllers/FileUploadController');
 const HelperService = require('../../../api/services/HelperService');
 const Application = require('../../../api/models/index').Application;
+const { max_files_per_application: maxFileLimit } =
+    require('../../../config/environment-variables').upload;
 
 const sandbox = sinon.sandbox.create();
 
@@ -189,7 +191,6 @@ describe('uploadFilesPage', () => {
             loggedIn: true,
             user: 'test_data',
         };
-        const maxFiles = '50';
         sandbox
             .stub(HelperService, 'getUserData')
             .callsFake(() => testUserData);
@@ -206,7 +207,7 @@ describe('uploadFilesPage', () => {
         );
         expect(resStub.view.getCall(0).args[1]).to.deep.equal({
             user_data: testUserData,
-            maxFiles: maxFiles,
+            maxFiles: maxFileLimit,
             backLink: '/eapp-start-page',
             messages: {
                 displayFilenameErrors: [],

--- a/views/eApostilles/openEApp.ejs
+++ b/views/eApostilles/openEApp.ejs
@@ -148,5 +148,11 @@
 
         <p>Your payment will appear on your bank statement as FCDO Legalisation Service.</p>
 
-        <a href="/download-receipt/<%= applicationId %>" class="govuk-link govuk-!-margin-top-2" role="button" download="<%= applicationId %>.pdf">Download your receipt</a>
+        <a
+            href="/download-receipt/<%= applicationId %>"
+            class="govuk-link govuk-!-margin-top-2" role="button"
+            download="LegalisationPaymentReceipt-<%= applicationId %>.pdf"
+        >
+            Download your receipt
+        </a>
     </section>


### PR DESCRIPTION
# Description

https://consular.atlassian.net/browse/EIA-504

The purpose of this ticket is to rename the the downloaded file and add `LegalisationPaymentReceipt-` to the file name.

 
<img width="541" alt="Screenshot 2022-05-23 at 12 26 11" src="https://user-images.githubusercontent.com/1377253/169811402-05592aea-c144-4a8e-b5c4-96558ec3d528.png">

