### PR TITLE
refactor: remove unnecessary progress bar code

### DIFF
--- a/assets/js/uploadFileProgressBar.js
+++ b/assets/js/uploadFileProgressBar.js
@@ -1,7 +1,4 @@
 var timeStarted = 0;
-var totalFilesToUpload = 0;
-var totalBytesToUpload = 0;
-var totalBytesUploaded = 0;
 var uploadBtn = document.querySelector('.js-trigger-progress-bar');
 
 var UploadProgressBar = {
@@ -16,7 +13,6 @@ var UploadProgressBar = {
             if (hasSelectedFiles) {
                 timeStarted = new Date();
                 UploadProgressBar.hideUploadButtonAndShowProgressBar();
-                UploadProgressBar.pretendToSendFormData();
             }
 
             setTimeout(function () {
@@ -39,56 +35,6 @@ var UploadProgressBar = {
         progressBar.classList.remove('govuk-!-display-none');
     },
 
-    pretendToSendFormData: function () {
-        var request = new XMLHttpRequest();
-        var emptyPostRequest = '';
-        var formData = UploadProgressBar.createDataForForm();
-
-        request.upload.addEventListener('progress', function (event) {
-            var progressPct = Math.round((event.loaded / event.total) * 100);
-            var progressBar = document.querySelector('.js-upload-progress-bar');
-
-            progressBar.ariaValueNow = progressPct;
-            progressBar.style.width = progressPct + '%';
-            totalBytesToUpload = event.total;
-            totalBytesUploaded = event.loaded;
-
-            if (event.loaded === event.total) {
-                UploadProgressBar.showFileScanning();
-            }
-        });
-
-        request.onerror = function (err) {
-            console.error(err, 'PretendToSendFormData Error');
-        };
-
-        request.open('post', emptyPostRequest);
-        request.send(formData);
-    },
-
-    createDataForForm: function () {
-        var uploadInput = document.querySelector('.js-multi-file-input');
-        var formData = new FormData();
-        var fileListArr = Array.from(uploadInput.files);
-
-        totalFilesToUpload = uploadInput.files.length;
-        fileListArr.forEach(function (file, index) {
-             // formData.append('file' + index, file);
-        });
-
-        return formData;
-    },
-
-    showFileScanning: function () {
-        var progressBar = document.querySelector('.js-upload-progress-bar');
-        var progressBarText = document.querySelector(
-            '.js-upload-progress-text'
-        );
-
-        progressBar.classList.add('upload-progress__bar--stripes');
-        progressBarText.innerHTML =
-            'Checking documents and scanning for viruses...';
-    },
 };
 
 function browserIsIE() {

--- a/assets/styles/informed.scss
+++ b/assets/styles/informed.scss
@@ -2067,6 +2067,7 @@ caption {
       );
       background-size: 200% 200%;
       animation: barberpole 10s linear infinite;
+      width: 100%;
     }
   }
 }

--- a/config/http.js
+++ b/config/http.js
@@ -15,10 +15,10 @@ module.exports.http = {
     order: [
       'cookieParser',
       'session',
+      'flash',
       'fileMiddleware',
       'bodyParser',
       'compress',
-      'flash',
       'updateLoggedInCookie',
       'clearHeaders',
       'poweredBy',
@@ -29,10 +29,7 @@ module.exports.http = {
     flash: require('connect-flash')(),
 
 
-    fileMiddleware: (function (arg1, arg2, arg3) {
-      console.log(arg1, 'arg1')
-      console.log(arg2, 'arg2')
-      console.log(arg3, 'arg3')
+    fileMiddleware: (function () {
       return require('../api/controllers/FileUploadController').setupMulterMiddleware()
     })(),
 

--- a/config/http.js
+++ b/config/http.js
@@ -29,7 +29,10 @@ module.exports.http = {
     flash: require('connect-flash')(),
 
 
-    fileMiddleware: (function () {
+    fileMiddleware: (function (arg1, arg2, arg3) {
+      console.log(arg1, 'arg1')
+      console.log(arg2, 'arg2')
+      console.log(arg3, 'arg3')
       return require('../api/controllers/FileUploadController').setupMulterMiddleware()
     })(),
 

--- a/views/applicationForms/applicationType.ejs
+++ b/views/applicationForms/applicationType.ejs
@@ -142,7 +142,7 @@
                             <a href="<%= sails.config.views.locals.start_url %>" class="govuk-link">Find out more about business-only premium.</a>
                         </div>
                     </div>
-                    <%// if(user_data.user && user_data.user.dropOffEnabled){%>
+                    <%if(user_data.user && user_data.user.dropOffEnabled){%>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="dropoff-service" name="choose-a-service" type="radio" value="dropoff">
                             <label class="govuk-label govuk-radios__label" for="dropoff-service">
@@ -156,7 +156,7 @@
                                 </ul>
                             </div>
                         </div>
-                    <%// }%>
+                    <%}%>
                 </section>
             </div>
             <button class="govuk-button govuk-!-margin-top-3" data-module="govuk-button">

--- a/views/eApostilles/uploadFiles.ejs
+++ b/views/eApostilles/uploadFiles.ejs
@@ -107,7 +107,7 @@
             <label class="js-upload-progress-text form-label-bold" for="upload-progress-bar" id="progressbarLabel">
                 Uploading document(s) and scanning for viruses...
             </label>
-            <div class="js-upload-progress-bar upload-progress__bar upload-progress__bar--stripes" style="width: 100%"></div>
+            <div class="js-upload-progress-bar upload-progress__bar upload-progress__bar--stripes"></div>
         </div>
 
         <% if (uploadedFileData.length > 0 || displayFilenameErrorsExists) { %>

--- a/views/eApostilles/uploadFiles.ejs
+++ b/views/eApostilles/uploadFiles.ejs
@@ -105,9 +105,9 @@
 
         <div class="js-progress-bar govuk-!-display-none govuk-!-margin-bottom-4" aria-live="polite">
             <label class="js-upload-progress-text form-label-bold" for="upload-progress-bar" id="progressbarLabel">
-                Uploading...
+                Uploading document(s) and scanning for viruses...
             </label>
-            <div class="js-upload-progress-bar upload-progress__bar" aria-labelledby="progressbarLabel" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+            <div class="js-upload-progress-bar upload-progress__bar upload-progress__bar--stripes" style="width: 100%"></div>
         </div>
 
         <% if (uploadedFileData.length > 0 || displayFilenameErrorsExists) { %>


### PR DESCRIPTION
# Description

The purpose of this PR is to remove the obsolete code in the upload file progress bar.

The progress bar animation had to be removed because:
- it didn't work well in safari
- it didn't work will with the updated version of Sailsjs

Because of that the only thing that is shown is the stripy bar animation whenever a file is uploaded.

<img width="608" alt="Screenshot 2022-05-30 at 12 57 26" src="https://user-images.githubusercontent.com/1377253/171025712-e0f1adb9-5875-4660-a037-821774ed3af6.png">


## Also...

There is another change in this PR but I've details that in a commit message so please feel free to refer to that during your review.