### PR TITLE
fix: remove unecessary timeout

### DIFF
--- a/assets/js/uploadFileProgressBar.js
+++ b/assets/js/uploadFileProgressBar.js
@@ -1,23 +1,17 @@
-var timeStarted = 0;
 var uploadBtn = document.querySelector('.js-trigger-progress-bar');
 
 var UploadProgressBar = {
     init: function () {
-        var timeoutToTriggerLoaderInSafari = 1000;
-
         uploadBtn.setAttribute('type', 'button');
 
         uploadBtn.addEventListener('click', function (_event) {
             var hasSelectedFiles = UploadProgressBar.checkFilesSelected();
 
             if (hasSelectedFiles) {
-                timeStarted = new Date();
-                UploadProgressBar.hideUploadButtonAndShowProgressBar();
+                UploadProgressBar.hideUploadButtonShowProgressBar();
             }
 
-            setTimeout(function () {
-                document.querySelector('.js-upload-form').submit();
-            }, timeoutToTriggerLoaderInSafari);
+            document.querySelector('.js-upload-form').submit();
         });
     },
 
@@ -27,7 +21,7 @@ var UploadProgressBar = {
         return fileInput.files.length > 0;
     },
 
-    hideUploadButtonAndShowProgressBar: function () {
+    hideUploadButtonShowProgressBar: function () {
         var uploadBtn = document.querySelector('.js-upload-btn');
         var progressBar = document.querySelector('.js-progress-bar');
 


### PR DESCRIPTION
# Description

The purpose of this PR is to fix an issue where uploading large or multiple files freezes the loading animation in Safari
https://consular.atlassian.net/browse/EIA-474

![f1601859-45b0-4a30-b535-4299a4be7614](https://user-images.githubusercontent.com/1377253/173338154-4c6f7ddf-0e38-4f5e-9ef3-efd37519c94b.png)

