### PR TITLE
Feat/eia 525 feedback consent

### DIFF
--- a/tests/specs/controllers/FileUpload.test.js
+++ b/tests/specs/controllers/FileUpload.test.js
@@ -165,6 +165,9 @@ describe('uploadFilesPage', () => {
             files: [],
             session: {
                 appId: 123,
+                account: {
+                    feedback_consent: true,
+                },
                 eApp: {
                     uploadFileData: [],
                 },
@@ -211,7 +214,7 @@ describe('uploadFilesPage', () => {
             .callsFake(() => testUserData);
         sandbox.stub(NodeClam.prototype, 'init').resolves();
         sandbox
-            .stub(FileUploadController, '_addSignedInIdToApplication').resolves();
+            .stub(FileUploadController, '_addSignedInDetailsToApplication').resolves();
         reqStub.flash = () => [];
 
         await FileUploadController.uploadFilesPage(reqStub, resStub);


### PR DESCRIPTION
# Description

The purpose of this PR is is to add the feedback consent form the account table to the eApp application when a user creates an application.

How the current service works is that there is a feedback consent section with radio buttons (yes/no) and whatever the user selects will get added to the application in the DB

We don't have this for eApp, so we're just grabbing the feedback consent from the personal details section (table in DB), and adding it to the application itself. 

<img width="877" alt="Screenshot 2022-06-15 at 11 27 39" src="https://user-images.githubusercontent.com/1377253/173806083-dd4a5130-b72d-47a4-9b05-cbf3333ea34c.png">

In the future we think they might put radio buttons there, but this is good for now.

Let me know if you have any questions on this, I don't know if I've added enough information.

