### PR TITLE
Fix/eia 515 multiple submissions

### DIFF
--- a/api/helper/addUserDataToDB.js
+++ b/api/helper/addUserDataToDB.js
@@ -25,7 +25,7 @@ async function addUserDataToDB(req, res) {
                 where: { application_id: userDetails.application_id },
             });
 
-        if (dataForThisApplicationAlreadyExists) return;
+       if (dataForThisApplicationAlreadyExists) return;
 
         await UsersBasicDetails.create(userDetails);
     } catch (error) {

--- a/api/helper/addUserDataToDB.js
+++ b/api/helper/addUserDataToDB.js
@@ -20,6 +20,13 @@ async function addUserDataToDB(req, res) {
             has_email: true,
         };
 
+        const dataForThisApplicationAlreadyExists =
+            await UsersBasicDetails.findOne({
+                where: { application_id: userDetails.application_id },
+            });
+
+        if (dataForThisApplicationAlreadyExists) return;
+
         await UsersBasicDetails.create(userDetails);
     } catch (error) {
         sails.log.error(error);

--- a/tests/specs/helpers/addUserDataToDB.test.js
+++ b/tests/specs/helpers/addUserDataToDB.test.js
@@ -2,7 +2,8 @@ const chai = require('chai');
 const sinon = require('sinon');
 const addUserDataToDB = require('../../../api/helper/addUserDataToDB');
 const UserModels = require('../../../api/userServiceModels/models.js');
-const UsersBasicDetails = require('../../../api/models/index').UsersBasicDetails;
+const UsersBasicDetails =
+    require('../../../api/models/index').UsersBasicDetails;
 
 const expect = chai.expect;
 const sandbox = sinon.sandbox.create();
@@ -15,13 +16,13 @@ describe('addUserDataToDB', () => {
         reqStub = {
             session: {
                 appId: 123,
-                email: 'test@example.com'
-            }
-        }
+                email: 'test@example.com',
+            },
+        };
 
         resStub = {
-            serverError: () => {}
-        }
+            serverError: () => {},
+        };
     });
 
     afterEach(() => {
@@ -32,7 +33,7 @@ describe('addUserDataToDB', () => {
         // when
         let callCount = 0;
         sandbox.stub(UserModels.User, 'findOne').resolves({
-            email: 'test@example.com'
+            email: 'test@example.com',
         });
 
         sandbox.stub(UserModels.AccountDetails, 'findOne').resolves({
@@ -56,6 +57,6 @@ describe('addUserDataToDB', () => {
         userData = await addUserDataToDB(reqStub, resStub);
 
         // then
-        expect(dimSum.callCount).to.equal(1)
-    })
-})
+        expect(dimSum.callCount).to.equal(1);
+    });
+});

--- a/tests/specs/helpers/addUserDataToDB.test.js
+++ b/tests/specs/helpers/addUserDataToDB.test.js
@@ -1,0 +1,53 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const addUserDataToDB = require('../../../api/helper/addUserDataToDB');
+const UserModels = require('../../../api/userServiceModels/models.js');
+const UsersBasicDetails = require('../../../api/models/index').UsersBasicDetails;
+
+const sandbox = sinon.sandbox.create();
+
+describe('addUserDataToDB', () => {
+    let reqStub;
+    let resStub;
+
+    beforeEach(() => {
+        reqStub = {
+            session: {
+                appId: 123,
+                email: 'test@example.com'
+            }
+        }
+
+        resStub = {
+            serverError: () => {}
+        }
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it('creates data ONLY once no matter how often function is run', async () => {
+        // when
+        sandbox.stub(UserModels.User, 'findOne').resolves({
+            email: 'test@example.com'
+        });
+
+        sandbox.stub(UserModels.AccountDetails, 'findOne').resolves({
+            first_name: 'Joe',
+            last_name: 'Bloggs',
+            telephone: '0123456789',
+            mobileNo: '07123456789',
+        });
+
+        const createUserDetails = sandbox.spy(UsersBasicDetails, 'create');
+
+        let data = await addUserDataToDB(reqStub, resStub);
+        data = await addUserDataToDB(reqStub, resStub);
+        data = await addUserDataToDB(reqStub, resStub);
+        data = await addUserDataToDB(reqStub, resStub);
+
+        // then
+        expect(createUserDetails.calledOnce).to.be.true;
+    })
+})

--- a/tests/specs/helpers/addUserDataToDB.test.js
+++ b/tests/specs/helpers/addUserDataToDB.test.js
@@ -28,7 +28,7 @@ describe('addUserDataToDB', () => {
         sandbox.restore();
     });
 
-    it.only('creates data ONLY once no matter how often function is run', async () => {
+    it('creates data ONLY once no matter how often function is run', async () => {
         // when
         let callCount = 0;
         sandbox.stub(UserModels.User, 'findOne').resolves({


### PR DESCRIPTION
# Description

The purpose of this PR is to fix a bug where a submitted application will show up more than once on the dashboard.

This happens because a function was adding the data to the db when the summary page loaded.

This PR fixes the issue by checking if the data is already in the database before submitting it.