### PR TITLE
Fix/eia 531 email link

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -63,6 +63,7 @@ const AuthController = {
             userData.premiumEnabled || req.query.name !== 'premiumCheck';
 
         if (midEAppFlow) redirectUrl = '/upload-files';
+        else if (req.query.eappid) redirectUrl = `open-eapp/${req.query.eappid}`;
         else if (hasPremiumAccount) redirectUrl = '/start';
         else if (!redirectNameInQueryParam) redirectUrl = '/dashboard';
 

--- a/api/controllers/OpenEAppController.js
+++ b/api/controllers/OpenEAppController.js
@@ -13,8 +13,8 @@ const OpenEAppController = {
     async renderPage(req, res) {
         const userData = HelperService.getUserData(req, res);
         if (!userData.loggedIn) {
-            sails.log.error('Users not logged in');
-            return res.serverError();
+            sails.log.error('Users not logged in - redirect to sign in page');
+            return res.redirect(`${req._sails.config.customURLs.userServiceURL}/sign-in?eappid=${req.params.unique_app_id}`);
         }
 
         try {

--- a/tests/specs/controllers/OpenEAppController.test.js
+++ b/tests/specs/controllers/OpenEAppController.test.js
@@ -89,7 +89,7 @@ describe('OpenEAppController', () => {
                 config: {
                     hmacKey: '123',
                     customURLs: {
-                        userServiceURL: 'http://localhost/3000/'
+                        userServiceURL: 'localhost/3000/'
                     },
                     casebookCertificate: '123',
                     casebookKey: '123',
@@ -125,7 +125,7 @@ describe('OpenEAppController', () => {
         await OpenEAppController.renderPage(reqStub, resStub);
 
         // then
-        expect(resStub.redirect.firstCall.args[0]).to.equal('http://localhost/3000//sign-in?eappid=test_unique_app_id');
+        expect(resStub.redirect.firstCall.args[0]).to.equal('localhost/3000/sign-in?eappid=test_unique_app_id');
     });
 
     it('prevents viewing the page if application ref is undefined', async () => {

--- a/tests/specs/controllers/OpenEAppController.test.js
+++ b/tests/specs/controllers/OpenEAppController.test.js
@@ -88,7 +88,9 @@ describe('OpenEAppController', () => {
             _sails: {
                 config: {
                     hmacKey: '123',
-                    customURLs: '123',
+                    customURLs: {
+                        userServiceURL: 'http://localhost/3000/'
+                    },
                     casebookCertificate: '123',
                     casebookKey: '123',
                     upload: {
@@ -105,6 +107,7 @@ describe('OpenEAppController', () => {
         resStub = {
             serverError: sandbox.stub(),
             forbidden: sandbox.stub(),
+            redirect: sandbox.stub(),
             view: sandbox.stub(),
         };
         sandbox.spy(sails.log, 'error');
@@ -114,7 +117,7 @@ describe('OpenEAppController', () => {
         sandbox.restore();
     });
 
-    it('should prevent viewing the page if user is not logged in', async () => {
+    it('should redirect to sign in page if user is not logged in', async () => {
         // when
         sandbox.stub(HelperService, 'getUserData').callsFake(() => ({
             loggedIn: false,
@@ -122,7 +125,7 @@ describe('OpenEAppController', () => {
         await OpenEAppController.renderPage(reqStub, resStub);
 
         // then
-        expect(resStub.serverError.called).to.be.true;
+        expect(resStub.redirect.firstCall.args[0]).to.equal('http://localhost/3000//sign-in?eappid=test_unique_app_id');
     });
 
     it('prevents viewing the page if application ref is undefined', async () => {

--- a/tests/specs/controllers/OpenEAppController.test.js
+++ b/tests/specs/controllers/OpenEAppController.test.js
@@ -89,7 +89,7 @@ describe('OpenEAppController', () => {
                 config: {
                     hmacKey: '123',
                     customURLs: {
-                        userServiceURL: 'localhost/3000/'
+                        userServiceURL: 'localhost/3000'
                     },
                     casebookCertificate: '123',
                     casebookKey: '123',

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -45,7 +45,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!--STYLES-->
-    <link rel="stylesheet" href="/styles/importer.1655727270763.css">
+    <link rel="stylesheet" href="/styles/importer.1655994226719.css">
     <!--STYLES END-->
     <link rel="stylesheet" href="/fonts/flaticon.css">
 


### PR DESCRIPTION
# Description

The purpose of this PR is to let the user know how to view an eApp if they are not signed in.

The issue was a user would click on the direct link to an eApp from their email after it has been legalised but, would be presented with an error because they are not logged in. This PR (with the combination of another), hopes to fix that issue.

https://user-images.githubusercontent.com/1377253/175323562-57c7b863-7651-4512-9af4-e7c208ec3a44.mp4


