### PR TITLE
FCDO-1743: e-App quirks

### DIFF
--- a/tests/specs/controllers/CheckUploadedDocuments.test.js
+++ b/tests/specs/controllers/CheckUploadedDocuments.test.js
@@ -112,7 +112,7 @@ describe('CheckUploadedDocumentsController', () => {
             };
 
             // then
-            expect(checkCountSpy.calledWith(params, resStub)).to.be.true;
+            expect(checkCountSpy.calledWith(reqStub, resStub, params)).to.be.true;
         });
     });
 


### PR DESCRIPTION
Render the payment error view when a user tries to submit an app, but their session hasn't been reset. This can happen if they pay successfully and use the back button to submit another app.